### PR TITLE
Rename prefix `makepdf:` to `builtin:`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 *.pdf
+*.lua

--- a/assets/scripts/panda.lua
+++ b/assets/scripts/panda.lua
@@ -4,25 +4,15 @@
 -- Recreation of the planner that has a panda.
 -------------------------------------------------------------------------------
 
-local f = pdf.font
-local o = pdf.object
-local u = pdf.utils
-
-for _, id in ipairs(f.ids()) do
-    local is_fallback = f.fallback() == id
-    print("Font " .. id .. (is_fallback and " (fallback)" or ""))
-end
-
 pdf.page.fill_color = "#999999"
 
-print("hello world")
 pdf.hooks.on_monthly_page(function(page)
-    page.push(o.rect({
+    page.push(pdf.object.rect({
         { 0,  0 },
         { 50, 50 },
     }))
 
-    page.push(o.text({
+    page.push(pdf.object.text({
         { 0, pdf.page.height - 25 },
         text = "Page " .. page.id,
     }))

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,13 +43,15 @@ enum Commands {
         open: bool,
 
         /// Destination for the created PDF file.
-        #[arg(short, long, default_value_t = String::from("planner.pdf"))]
-        output: String,
+        ///
+        /// When no output provided, will use the title as the filename.
+        #[arg(short, long)]
+        output: Option<String>,
 
         /// Path to the script to use to build the PDF.
         ///
         /// Internal scripts are referenced using a special syntax of
-        /// `makepdf:{NAME}` where the name is prefixed with `makepdf:`.
+        /// `builtin:{NAME}` where the name is the builtin script's name.
         #[arg(short, long, default_value_t = PdfConfig::default().script)]
         script: String,
 
@@ -85,6 +87,11 @@ fn main() -> anyhow::Result<()> {
         } => {
             // Translate our dimensions into a width and height we will use for the PDF pages
             let (width, height) = PdfConfigPage::parse_size(&dimensions, dpi)?;
+
+            // If output is not specified, we will use the script's title with a .pdf extension
+            let output = output.unwrap_or_else(|| {
+                format!("{}.pdf", title.replace(|c: char| !c.is_alphanumeric(), "_"))
+            });
 
             // Build our initial configuration based on the commandline arguments and defaults
             let config = PdfConfig {

--- a/src/pdf/config.rs
+++ b/src/pdf/config.rs
@@ -18,7 +18,7 @@ pub struct PdfConfig {
     pub page: PdfConfigPage,
     /// Configuration tied to a PDF planner
     pub planner: PdfConfigPlanner,
-    /// Path or name of script (e.g. `makepdf:panda`)
+    /// Path or name of script (e.g. `builtin:panda`)
     pub script: String,
     /// Title of the pdf document
     pub title: String,
@@ -33,7 +33,7 @@ impl Default for PdfConfig {
         Self {
             page,
             planner,
-            script: String::from("makepdf:panda"),
+            script: String::from("makepdf.lua"),
             title: format!("Planner {year}"),
         }
     }

--- a/src/runtime/script.rs
+++ b/src/runtime/script.rs
@@ -14,7 +14,7 @@ pub struct RuntimeScript {
 
 impl RuntimeScript {
     /// Prefix used for internal script access.
-    const PREFIX: &'static str = "makepdf:";
+    const PREFIX: &'static str = "builtin:";
 
     /// Loads a script from a file (or internally) to be executed.
     ///


### PR DESCRIPTION

Summary: Renames prefix `makepdf:` used to detect a builtin script to use `builtin:` instead. Also changes the --script default to be `makepdf.lua` instead of `builtin:panda`.

Test Plan:

```
# When we have a makepdf.lua file
makepdf make

# To test the builtin file
makepdf make --script builtin:panda
```
