### PR TITLE
Add stdlib integration

### DIFF
--- a/assets/scripts/definitions.lua
+++ b/assets/scripts/definitions.lua
@@ -1,5 +1,9 @@
 ---@meta
----Primary definition file representing makepdf's Lua library.
+-------------------------------------------------------------------------------
+-- DEFINITIONS
+--
+-- Primary definition file representing makepdf's Lua library.
+-------------------------------------------------------------------------------
 
 ---@class pdf
 pdf = {}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,6 +6,7 @@ pub const GLOBAL_PDF_VAR_NAME: &str = "pdf";
 
 /// Internal scripts available to be run.
 pub static SCRIPTS: phf::Map<&'static str, &[u8]> = phf::phf_map! {
+    "stdlib" => include_bytes!("../assets/scripts/stdlib.lua"),
     "example" => include_bytes!("../assets/scripts/example.lua"),
     "panda" => include_bytes!("../assets/scripts/panda.lua"),
 };

--- a/src/runtime/script.rs
+++ b/src/runtime/script.rs
@@ -52,6 +52,16 @@ impl RuntimeScript {
 
     /// Executes the script. This will eagerly parse and execute the code.
     pub fn exec(&self) -> anyhow::Result<()> {
+        // Before running our user script, we first want to set up additional functionality
+        // via the stdlib script, which should augment what we can do
+        if let Some(stdlib) = SCRIPTS.get("stdlib") {
+            self.lua
+                .load(*stdlib)
+                .exec()
+                .context("Failed to execute stdlib script")?;
+        }
+
+        // Now, execute the user script
         self.lua
             .load(&self.bytes)
             .exec()


### PR DESCRIPTION

Summary: Adds `stdlib.lua` that is executed before the main user script, which enables us to extend functionality of the `pdf` global without needing to write even more Rust code. So, faster iteration.

Test Plan: Observe that there is now a `pdf.object.rect_text()` function.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/chipsenkbeil/makepdf/pull/8).
* #9
* __->__ #8