### PR TITLE
Support bounds alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
 *.pdf
 *.lua
+!assets/scripts/*.lua
 **/.DS_Store

--- a/assets/scripts/definitions.lua
+++ b/assets/scripts/definitions.lua
@@ -94,22 +94,12 @@ pdf.planner = {
 local PdfBounds = {}
 
 ---Calculates the width of the bounds.
----
----Note that if `this` is not provided, then changes made to the bounds
----will not be leveraged.
----
----@param this? pdf.common.Bounds #if provided, will return width dynamically from `this`
 ---@return number
-function PdfBounds.width(this) end
+function PdfBounds:width() end
 
 ---Calculates the height of the bounds.
----
----Note that if `this` is not provided, then changes made to the bounds
----will not be leveraged.
----
----@param this? pdf.common.Bounds #if provided, will return height dynamically from `this`
 ---@return number
-function PdfBounds.height(this) end
+function PdfBounds:height() end
 
 ---@class pdf.common.Date
 local PdfDate = {}
@@ -469,15 +459,8 @@ local PdfObjectText = {
 ---coordinates alongside the associated font. The returned bounds represent
 ---the total size and positioning of the text within the PDF accounting for
 ---ascenders (e.g. capital letters) and descenders (e.g. letters like 'g').
----
----Note that if `this` is not provided, then changes made to the text object
----such as the text, font, font size, or x & y coordinates will not be
----leveraged. If any of those have changed since the text object was created,
----you must recreate it to refresh the bounds calculation.
----
----@param this? pdf.object.Text #if provided, will return bounds dynamically for this text
 ---@return pdf.common.Bounds
-function PdfObjectText.bounds(this) end
+function PdfObjectText:bounds() end
 
 ---@class pdf.object.TextArgsBase
 local PdfObjectTextArgsBase = {

--- a/assets/scripts/stdlib.lua
+++ b/assets/scripts/stdlib.lua
@@ -1,0 +1,4 @@
+---
+---@return pdf.object.Group
+function pdf.object.rect_text()
+end

--- a/src/pdf/common.rs
+++ b/src/pdf/common.rs
@@ -1,3 +1,4 @@
+mod align;
 mod bounds;
 mod color;
 mod date;
@@ -8,6 +9,7 @@ mod order;
 mod point;
 mod space;
 
+pub use align::{PdfHorizontalAlign, PdfVerticalAlign};
 pub use bounds::PdfBounds;
 pub use color::PdfColor;
 pub use date::PdfDate;

--- a/src/pdf/common/align.rs
+++ b/src/pdf/common/align.rs
@@ -1,0 +1,89 @@
+use mlua::prelude::*;
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum PdfHorizontalAlign {
+    Left,
+    #[default]
+    Middle,
+    Right,
+}
+
+impl<'lua> IntoLua<'lua> for PdfHorizontalAlign {
+    #[inline]
+    fn into_lua(self, lua: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
+        lua.create_string(match self {
+            Self::Left => "left",
+            Self::Middle => "middle",
+            Self::Right => "right",
+        })
+        .map(LuaValue::String)
+    }
+}
+
+impl<'lua> FromLua<'lua> for PdfHorizontalAlign {
+    #[inline]
+    fn from_lua(value: LuaValue<'lua>, _lua: &'lua Lua) -> LuaResult<Self> {
+        let from = value.type_name();
+        match value {
+            LuaValue::String(s) => match s.to_string_lossy().as_ref() {
+                "left" => Ok(Self::Left),
+                "middle" => Ok(Self::Middle),
+                "right" => Ok(Self::Right),
+                ty => Err(LuaError::FromLuaConversionError {
+                    from,
+                    to: "pdf.common.horizontal_align",
+                    message: Some(format!("unknown alignment: {ty}")),
+                }),
+            },
+            _ => Err(LuaError::FromLuaConversionError {
+                from,
+                to: "pdf.common.horizontal_align",
+                message: None,
+            }),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum PdfVerticalAlign {
+    Top,
+    #[default]
+    Middle,
+    Bottom,
+}
+
+impl<'lua> IntoLua<'lua> for PdfVerticalAlign {
+    #[inline]
+    fn into_lua(self, lua: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
+        lua.create_string(match self {
+            Self::Top => "top",
+            Self::Middle => "middle",
+            Self::Bottom => "bottom",
+        })
+        .map(LuaValue::String)
+    }
+}
+
+impl<'lua> FromLua<'lua> for PdfVerticalAlign {
+    #[inline]
+    fn from_lua(value: LuaValue<'lua>, _lua: &'lua Lua) -> LuaResult<Self> {
+        let from = value.type_name();
+        match value {
+            LuaValue::String(s) => match s.to_string_lossy().as_ref() {
+                "top" => Ok(Self::Top),
+                "middle" => Ok(Self::Middle),
+                "bottom" => Ok(Self::Bottom),
+                ty => Err(LuaError::FromLuaConversionError {
+                    from,
+                    to: "pdf.common.vertical_align",
+                    message: Some(format!("unknown alignment: {ty}")),
+                }),
+            },
+            _ => Err(LuaError::FromLuaConversionError {
+                from,
+                to: "pdf.common.vertical_align",
+                message: None,
+            }),
+        }
+    }
+}


### PR DESCRIPTION

Summary: Adds new data types for vertical and horizontal alignment.
In addition, introduces a new method to PdfBounds that aligns the
bounds with another set of bounds, which can be used to fit text
on top of a rectangle.

Test Plan: `cargo test`
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/chipsenkbeil/makepdf/pull/11).
* #16
* #15
* #14
* #13
* #12
* __->__ #11