### PR TITLE
Add bounds() functions to all objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+.sl/
 *.pdf
 *.lua
 !assets/scripts/*.lua

--- a/assets/scripts/definitions.lua
+++ b/assets/scripts/definitions.lua
@@ -270,6 +270,10 @@ local PdfObjectGroup = {
     link = nil,
 }
 
+---Calculates the bounds that contains the entire set of objects within the group.
+---@return pdf.common.Bounds
+function PdfObjectGroup:bounds() end
+
 ---@class pdf.object.GroupArgs
 ---@field [number] pdf.Object
 local PdfObjectGroupArgs = {
@@ -303,6 +307,10 @@ local PdfObjectLine = {
     ---@type pdf.common.Link|nil
     link = nil,
 }
+
+---Calculates the bounds that contain all points within the lines.
+---@return pdf.common.Bounds
+function PdfObjectLine:bounds() end
 
 ---@class pdf.object.LineArgs
 ---@field [number] pdf.common.PointArg
@@ -344,6 +352,10 @@ local PdfObjectRect = {
     ---@type pdf.common.Link|nil
     link = nil,
 }
+
+---Returns the bounds of the rect.
+---@return pdf.common.Bounds
+function PdfObjectRect:bounds() end
 
 ---@class pdf.object.RectArgsBase
 local PdfObjectRectArgsBase = {
@@ -408,6 +420,10 @@ local PdfObjectShape = {
     link = nil,
 }
 
+---Calculates the bounds that contain all points within the shape.
+---@return pdf.common.Bounds
+function PdfObjectShape:bounds() end
+
 ---@class pdf.object.ShapeArgs
 ---@field [number] pdf.common.PointArg
 local PdfObjectShapeArgs = {
@@ -456,9 +472,11 @@ local PdfObjectText = {
 }
 
 ---Calculates the bounds of the text object by using its baseline x & y
----coordinates alongside the associated font. The returned bounds represent
----the total size and positioning of the text within the PDF accounting for
----ascenders (e.g. capital letters) and descenders (e.g. letters like 'g').
+---coordinates alongside the associated font.
+---
+---The returned bounds represent the total size and positioning of the text
+---within the PDF accounting for ascenders (e.g. capital letters) and
+---descenders (e.g. letters like 'g').
 ---@return pdf.common.Bounds
 function PdfObjectText:bounds() end
 

--- a/assets/scripts/stdlib.lua
+++ b/assets/scripts/stdlib.lua
@@ -1,4 +1,6 @@
----
----@return pdf.object.Group
-function pdf.object.rect_text()
-end
+-------------------------------------------------------------------------------
+-- STDLIB
+--
+-- Executed prior to the user script, enabling standard library implementations
+-- that are written in Lua. This is designed as faster turnaround than Rust.
+-------------------------------------------------------------------------------

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -45,6 +45,18 @@ impl PdfObject {
         }
     }
 
+    /// Calculates bounds from a [`Lua`] runtime, which occurs earlier than when a [`PdfContext`]
+    /// is available.
+    pub(crate) fn lua_bounds(&self, lua: &Lua) -> LuaResult<PdfBounds> {
+        Ok(match self {
+            Self::Group(x) => x.lua_bounds(lua)?,
+            Self::Line(x) => x.bounds(),
+            Self::Rect(x) => x.bounds,
+            Self::Shape(x) => x.bounds(),
+            Self::Text(x) => x.lua_bounds(lua)?,
+        })
+    }
+
     /// Returns depth of the object with 0 being the default.
     pub fn depth(&self) -> i64 {
         match self {

--- a/src/pdf/object/shape.rs
+++ b/src/pdf/object/shape.rs
@@ -1,12 +1,12 @@
 use crate::pdf::{
-    PdfBounds, PdfColor, PdfContext, PdfLink, PdfLinkAnnotation, PdfLuaTableExt, PdfPaintMode,
-    PdfPoint, PdfWindingOrder,
+    PdfBounds, PdfColor, PdfContext, PdfLink, PdfLinkAnnotation, PdfLuaExt, PdfLuaTableExt,
+    PdfPaintMode, PdfPoint, PdfWindingOrder,
 };
 use mlua::prelude::*;
 use printpdf::Polygon;
 
 /// Represents a line to be drawn in the PDF.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PdfObjectShape {
     pub points: Vec<PdfPoint>,
     pub depth: Option<i64>,
@@ -20,8 +20,20 @@ pub struct PdfObjectShape {
 impl PdfObjectShape {
     /// Returns bounds for the shape by getting the lower and upper point ranges.
     pub fn bounds(&self) -> PdfBounds {
-        let mut ll = PdfPoint::default();
-        let mut ur = PdfPoint::default();
+        // Set default for lower-left and upper-right to our first point, or
+        // default if we have no points. We do this to avoid the issue where
+        // the default point is 0,0 and all existing points are positive, the
+        // bounds would have a lower-left of 0,0.
+        let mut ll = self
+            .points
+            .first()
+            .copied()
+            .unwrap_or_else(PdfPoint::default);
+        let mut ur = self
+            .points
+            .first()
+            .copied()
+            .unwrap_or_else(PdfPoint::default);
 
         for point in self.points.iter() {
             if point.x < ll.x {
@@ -33,7 +45,7 @@ impl PdfObjectShape {
             }
 
             if point.y < ll.y {
-                ll.y = point.x;
+                ll.y = point.y;
             }
 
             if point.y > ur.y {
@@ -76,7 +88,7 @@ impl PdfObjectShape {
 impl<'lua> IntoLua<'lua> for PdfObjectShape {
     #[inline]
     fn into_lua(self, lua: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
-        let table = lua.create_table()?;
+        let (table, metatable) = lua.create_table_ext()?;
 
         // Add the points as a list
         for point in self.points {
@@ -90,6 +102,11 @@ impl<'lua> IntoLua<'lua> for PdfObjectShape {
         table.raw_set("mode", self.mode)?;
         table.raw_set("order", self.order)?;
         table.raw_set("link", self.link)?;
+
+        metatable.raw_set(
+            "bounds",
+            lua.create_function(move |_, this: Self| Ok(this.bounds()))?,
+        )?;
 
         Ok(LuaValue::Table(table))
     }
@@ -114,5 +131,82 @@ impl<'lua> FromLua<'lua> for PdfObjectShape {
                 message: None,
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pdf::Pdf;
+    use mlua::chunk;
+
+    #[test]
+    fn should_be_able_to_calculate_bounds_of_shape() {
+        // No points
+        let shape = PdfObjectShape::default();
+        assert_eq!(
+            shape.bounds(),
+            PdfBounds::from_coords_f32(0.0, 0.0, 0.0, 0.0)
+        );
+
+        // Single point
+        let shape = PdfObjectShape {
+            points: vec![PdfPoint::from_coords_f32(3.0, 4.0)],
+            ..Default::default()
+        };
+        assert_eq!(
+            shape.bounds(),
+            PdfBounds::from_coords_f32(3.0, 4.0, 3.0, 4.0)
+        );
+
+        // Multiple points
+        let shape = PdfObjectShape {
+            points: vec![
+                PdfPoint::from_coords_f32(1.0, 5.0),
+                PdfPoint::from_coords_f32(3.0, 4.0),
+            ],
+            ..Default::default()
+        };
+        assert_eq!(
+            shape.bounds(),
+            PdfBounds::from_coords_f32(1.0, 4.0, 3.0, 5.0)
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_calculate_bounds_of_shape_in_lua() {
+        // Stand up Lua runtime with everything configured properly for tests
+        let lua = Lua::new();
+        lua.globals().raw_set("pdf", Pdf::default()).unwrap();
+
+        lua.load(chunk! {
+            // No points
+            local shape = pdf.object.shape({})
+            pdf.utils.assert_deep_equal(shape:bounds(), {
+                ll = { x = 0, y = 0 },
+                ur = { x = 0, y = 0 },
+            })
+
+            // Single point
+            local shape = pdf.object.shape({
+                { x = 3, y = 4 },
+            })
+            pdf.utils.assert_deep_equal(shape:bounds(), {
+                ll = { x = 3, y = 4 },
+                ur = { x = 3, y = 4 },
+            })
+
+            // Multiple points
+            local shape = pdf.object.shape({
+                { x = 1, y = 5 },
+                { x = 3, y = 4 },
+            })
+            pdf.utils.assert_deep_equal(shape:bounds(), {
+                ll = { x = 1, y = 4 },
+                ur = { x = 3, y = 5 },
+            })
+        })
+        .exec()
+        .expect("Assertion failed");
     }
 }

--- a/src/pdf/object/text.rs
+++ b/src/pdf/object/text.rs
@@ -9,7 +9,7 @@ use owned_ttf_parser::{Face, GlyphId};
 use printpdf::{GlyphMetrics, Mm, Pt};
 
 /// Represents a line to be drawn in the PDF.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PdfObjectText {
     pub point: PdfPoint,
     pub text: String,
@@ -69,6 +69,48 @@ impl PdfObjectText {
             unreachable!("Fallback font should always be available");
         }
     }
+
+    /// Returns bounds for the text by calculating the width and height and applying to get the
+    /// upper-right-point.
+    ///
+    /// Calculates bounds from a [`Lua`] runtime, which occurs earlier than when a [`PdfContext`]
+    /// is available.
+    pub(crate) fn lua_bounds(&self, lua: &Lua) -> LuaResult<PdfBounds> {
+        // Figure out the font's size by loading the explicit size or searching our global
+        // pdf instance for the default page font size
+        let font_size = match self.size {
+            Some(size) => size,
+            None => {
+                lua.globals()
+                    .raw_get::<_, PdfConfig>(GLOBAL_PDF_VAR_NAME)?
+                    .page
+                    .font_size
+            }
+        };
+
+        // Retrieve the loaded fonts so we can figure out the actual text bounds
+        // for the associated font
+        if let Some(fonts) = lua.app_data_ref::<RuntimeFonts>() {
+            let font_id = match self.font {
+                Some(id) => Some(id),
+                None => fonts.fallback_font_id(),
+            };
+
+            if let Some(face) = font_id.and_then(|id| fonts.get_font_face(id)) {
+                Ok(bounds(
+                    &self.text,
+                    face,
+                    font_size,
+                    self.point.x,
+                    self.point.y,
+                ))
+            } else {
+                Err(LuaError::runtime("Runtime fallback font is missing"))
+            }
+        } else {
+            Err(LuaError::runtime("Runtime fonts are missing"))
+        }
+    }
 }
 
 fn glyph_metrics(face: &Face, glyph_id: u16) -> Option<GlyphMetrics> {
@@ -89,7 +131,6 @@ impl<'lua> IntoLua<'lua> for PdfObjectText {
     #[inline]
     fn into_lua(self, lua: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
         let (table, metatable) = lua.create_table_ext()?;
-        let text = self.text.to_string();
 
         self.point.add_to_table(&table)?;
         table.raw_set("text", self.text)?;
@@ -105,36 +146,7 @@ impl<'lua> IntoLua<'lua> for PdfObjectText {
         // the repository of fonts to get the information needed for the current text.
         metatable.raw_set(
             "bounds",
-            lua.create_function(move |lua, this: Self| {
-                // Figure out the font's size by loading the explicit size or searching our global
-                // pdf instance for the default page font size
-                let font_size = match this.size {
-                    Some(size) => size,
-                    None => {
-                        lua.globals()
-                            .raw_get::<_, PdfConfig>(GLOBAL_PDF_VAR_NAME)?
-                            .page
-                            .font_size
-                    }
-                };
-
-                // Retrieve the loaded fonts so we can figure out the actual text bounds
-                // for the associated font
-                if let Some(fonts) = lua.app_data_ref::<RuntimeFonts>() {
-                    let font_id = match this.font {
-                        Some(id) => Some(id),
-                        None => fonts.fallback_font_id(),
-                    };
-
-                    if let Some(face) = font_id.and_then(|id| fonts.get_font_face(id)) {
-                        Ok(bounds(&text, face, font_size, this.point.x, this.point.y))
-                    } else {
-                        Err(LuaError::runtime("Runtime fallback font is missing"))
-                    }
-                } else {
-                    Err(LuaError::runtime("Runtime fonts are missing"))
-                }
-            })?,
+            lua.create_function(move |lua, this: Self| this.lua_bounds(lua))?,
         )?;
 
         Ok(LuaValue::Table(table))
@@ -234,4 +246,71 @@ fn text_ll_y(face: &Face, font_size: f32, baseline_y: Mm) -> Mm {
     //       I believe this is because the baseline is considered origin (y=0),
     //       so going below it would yield a negative value.
     baseline_y + descender_mm
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pdf::Pdf;
+    use crate::runtime::RuntimeFonts;
+    use mlua::chunk;
+    use printpdf::{Mm, PdfDocument};
+
+    #[test]
+    fn should_be_able_to_calculate_bounds_of_text() {
+        // Create a pdf context that we need for bounds calculations
+        let doc = PdfDocument::empty("");
+        let (page_idx, layer_idx) = doc.add_page(Mm(0.0), Mm(0.0), "");
+        let layer = doc.get_page(page_idx).get_layer(layer_idx);
+        let mut font = RuntimeFonts::new();
+        let font_id = font.add_builtin_font().unwrap();
+        font.add_font_as_fallback(font_id);
+        let ctx = PdfContext {
+            config: &PdfConfig::default(),
+            layer: &layer,
+            fonts: &font,
+            fallback_font_id: font_id,
+        };
+
+        let text = PdfObjectText {
+            point: PdfPoint::from_coords_f32(0.0, 0.0),
+            text: String::from("hello world"),
+            size: Some(36.0),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            text.bounds(ctx),
+            PdfBounds::from_coords_f32(0.0, -3.810_002_3, 83.820_05, 12.954_007)
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_calculate_bounds_of_text_in_lua() {
+        // Stand up Lua runtime with everything configured properly for tests
+        let lua = Lua::new();
+        lua.globals().raw_set("pdf", Pdf::default()).unwrap();
+        lua.set_app_data({
+            let mut fonts = RuntimeFonts::new();
+            let id = fonts.add_builtin_font().unwrap();
+            fonts.add_font_as_fallback(id);
+            fonts
+        });
+
+        // Test the bounds, which should correctly cover full text
+        lua.load(chunk! {
+            local text = pdf.object.text({
+                x = 0,
+                y = 0,
+                text = "hello world",
+                size = 36.0,
+            })
+            pdf.utils.assert_deep_equal(text:bounds(), {
+                ll = { x = 0,                   y = -3.810002326965332 },
+                ur = { x = 83.82005310058594,   y = 12.954007148742676 },
+            })
+        })
+        .exec()
+        .expect("Assertion failed");
+    }
 }


### PR DESCRIPTION

Summary: Adds a :bounds() function to PdfObject and associated types.

Test Plan: `cargo test`
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/chipsenkbeil/makepdf/pull/12).
* #16
* #15
* #14
* #13
* __->__ #12