### PR TITLE
Implement align_to functions on objects

### DIFF
--- a/assets/scripts/definitions.lua
+++ b/assets/scripts/definitions.lua
@@ -67,6 +67,9 @@ pdf.planner = {
 ---@alias pdf.common.Point {x:number, y:number}
 ---@alias pdf.common.PaintMode "clip"|"fill"|"fill_stroke"|"stroke"
 ---@alias pdf.common.WindingOrder "even_odd"|"non_zero"
+---@alias pdf.common.Align {h:pdf.common.HorizontalAlign, v:pdf.common.VerticalAlign}
+---@alias pdf.common.HorizontalAlign "left"|"middle"|"right"
+---@alias pdf.common.VerticalAlign "top"|"middle"|"bottom"
 
 ---@alias pdf.common.Link
 ---| {type:"goto", page:integer}
@@ -92,6 +95,12 @@ pdf.planner = {
 ---@field ll pdf.common.Point
 ---@field ur pdf.common.Point
 local PdfBounds = {}
+
+---Aligns these bounds to the provided bounds, returning an updated bounds.
+---@param bounds pdf.common.Bounds
+---@param align pdf.common.Align
+---@return pdf.common.Bounds
+function PdfBounds:align_to(bounds, align) end
 
 ---Calculates the width of the bounds.
 ---@return number
@@ -270,6 +279,12 @@ local PdfObjectGroup = {
     link = nil,
 }
 
+---Aligns the group to the provided bounds, returning an updated group.
+---@param bounds pdf.common.Bounds
+---@param align pdf.common.Align
+---@return pdf.object.Group
+function PdfObjectGroup:align_to(bounds, align) end
+
 ---Calculates the bounds that contains the entire set of objects within the group.
 ---@return pdf.common.Bounds
 function PdfObjectGroup:bounds() end
@@ -307,6 +322,12 @@ local PdfObjectLine = {
     ---@type pdf.common.Link|nil
     link = nil,
 }
+
+---Aligns the line to the provided bounds, returning an updated line.
+---@param bounds pdf.common.Bounds
+---@param align pdf.common.Align
+---@return pdf.object.Line
+function PdfObjectLine:align_to(bounds, align) end
 
 ---Calculates the bounds that contain all points within the lines.
 ---@return pdf.common.Bounds
@@ -352,6 +373,12 @@ local PdfObjectRect = {
     ---@type pdf.common.Link|nil
     link = nil,
 }
+
+---Aligns the rect to the provided bounds, returning an updated rect.
+---@param bounds pdf.common.Bounds
+---@param align pdf.common.Align
+---@return pdf.object.Rect
+function PdfObjectRect:align_to(bounds, align) end
 
 ---Returns the bounds of the rect.
 ---@return pdf.common.Bounds
@@ -420,6 +447,12 @@ local PdfObjectShape = {
     link = nil,
 }
 
+---Aligns the shape to the provided bounds, returning an updated shape.
+---@param bounds pdf.common.Bounds
+---@param align pdf.common.Align
+---@return pdf.object.Shape
+function PdfObjectShape:align_to(bounds, align) end
+
 ---Calculates the bounds that contain all points within the shape.
 ---@return pdf.common.Bounds
 function PdfObjectShape:bounds() end
@@ -470,6 +503,12 @@ local PdfObjectText = {
     ---@type pdf.common.Link|nil
     link = nil,
 }
+
+---Aligns the text to the provided bounds, returning an updated text.
+---@param bounds pdf.common.Bounds
+---@param align pdf.common.Align
+---@return pdf.object.Text
+function PdfObjectText:align_to(bounds, align) end
 
 ---Calculates the bounds of the text object by using its baseline x & y
 ---coordinates alongside the associated font.

--- a/src/pdf/common.rs
+++ b/src/pdf/common.rs
@@ -9,7 +9,7 @@ mod order;
 mod point;
 mod space;
 
-pub use align::{PdfHorizontalAlign, PdfVerticalAlign};
+pub use align::{PdfAlign, PdfHorizontalAlign, PdfVerticalAlign};
 pub use bounds::PdfBounds;
 pub use color::PdfColor;
 pub use date::PdfDate;

--- a/src/pdf/common/align.rs
+++ b/src/pdf/common/align.rs
@@ -1,4 +1,52 @@
+use crate::pdf::PdfLuaTableExt;
 use mlua::prelude::*;
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct PdfAlign {
+    pub h: PdfHorizontalAlign,
+    pub v: PdfVerticalAlign,
+}
+
+impl PdfAlign {
+    /// Convert to (horizontal, vertical) tuple.
+    pub fn to_h_v(self) -> (PdfHorizontalAlign, PdfVerticalAlign) {
+        (self.h, self.v)
+    }
+
+    /// Convert to (vertical, horizontal) tuple.
+    pub fn to_v_h(self) -> (PdfVerticalAlign, PdfHorizontalAlign) {
+        (self.v, self.h)
+    }
+}
+
+impl<'lua> IntoLua<'lua> for PdfAlign {
+    #[inline]
+    fn into_lua(self, lua: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
+        let table = lua.create_table()?;
+        table.raw_set("h", self.h)?;
+        table.raw_set("v", self.v)?;
+
+        Ok(LuaValue::Table(table))
+    }
+}
+
+impl<'lua> FromLua<'lua> for PdfAlign {
+    #[inline]
+    fn from_lua(value: LuaValue<'lua>, _lua: &'lua Lua) -> LuaResult<Self> {
+        let from = value.type_name();
+        match value {
+            LuaValue::Table(tbl) => Ok(Self {
+                h: tbl.raw_get_ext("h")?,
+                v: tbl.raw_get_ext("v")?,
+            }),
+            _ => Err(LuaError::FromLuaConversionError {
+                from,
+                to: "pdf.common.horizontal_align",
+                message: None,
+            }),
+        }
+    }
+}
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub enum PdfHorizontalAlign {

--- a/src/pdf/common/bounds.rs
+++ b/src/pdf/common/bounds.rs
@@ -75,14 +75,9 @@ impl PdfBounds {
         (llx.0, lly.0, urx.0, ury.0)
     }
 
-    /// Returns a new bounds aligned to some other bounds based on `halign` and `valign`
-    /// configuration.
-    pub fn align_to(
-        &self,
-        other: Self,
-        halign: PdfHorizontalAlign,
-        valign: PdfVerticalAlign,
-    ) -> Self {
+    /// Returns a new bounds aligned to some other bounds based on `align`.
+    pub fn align_to(&self, other: Self, align: (PdfVerticalAlign, PdfHorizontalAlign)) -> Self {
+        let (valign, halign) = align;
         let x_offset = match halign {
             PdfHorizontalAlign::Left => other.ll.x - self.ll.x,
             PdfHorizontalAlign::Middle => {
@@ -203,6 +198,9 @@ mod tests {
 
     #[test]
     fn should_support_aligning_with_another_set_of_bounds() {
+        type H = PdfHorizontalAlign;
+        type V = PdfVerticalAlign;
+
         // 5x5 square
         let this = PdfBounds::from_coords_f32(1.0, 1.0, 6.0, 6.0);
 
@@ -210,39 +208,39 @@ mod tests {
         let other = PdfBounds::from_coords_f32(5.0, 5.0, 25.0, 25.0);
 
         // Upper-left
-        let actual = this.align_to(other, PdfHorizontalAlign::Left, PdfVerticalAlign::Top);
+        let actual = this.align_to(other, (V::Top, H::Left));
         assert_eq!(actual.to_coords_f32(), (5.0, 20.0, 10.0, 25.0));
 
         // Upper-middle
-        let actual = this.align_to(other, PdfHorizontalAlign::Middle, PdfVerticalAlign::Top);
+        let actual = this.align_to(other, (V::Top, H::Middle));
         assert_eq!(actual.to_coords_f32(), (12.5, 20.0, 17.5, 25.0));
 
         // Upper-right
-        let actual = this.align_to(other, PdfHorizontalAlign::Right, PdfVerticalAlign::Top);
+        let actual = this.align_to(other, (V::Top, H::Right));
         assert_eq!(actual.to_coords_f32(), (20.0, 20.0, 25.0, 25.0));
 
         // Middle-left
-        let actual = this.align_to(other, PdfHorizontalAlign::Left, PdfVerticalAlign::Middle);
+        let actual = this.align_to(other, (V::Middle, H::Left));
         assert_eq!(actual.to_coords_f32(), (5.0, 12.5, 10.0, 17.5));
 
         // Middle-middle
-        let actual = this.align_to(other, PdfHorizontalAlign::Middle, PdfVerticalAlign::Middle);
+        let actual = this.align_to(other, (V::Middle, H::Middle));
         assert_eq!(actual.to_coords_f32(), (12.5, 12.5, 17.5, 17.5));
 
         // Middle-right
-        let actual = this.align_to(other, PdfHorizontalAlign::Right, PdfVerticalAlign::Middle);
+        let actual = this.align_to(other, (V::Middle, H::Right));
         assert_eq!(actual.to_coords_f32(), (20.0, 12.5, 25.0, 17.5));
 
         // Bottom-left
-        let actual = this.align_to(other, PdfHorizontalAlign::Left, PdfVerticalAlign::Bottom);
+        let actual = this.align_to(other, (V::Bottom, H::Left));
         assert_eq!(actual.to_coords_f32(), (5.0, 5.0, 10.0, 10.0));
 
         // Bottom-middle
-        let actual = this.align_to(other, PdfHorizontalAlign::Middle, PdfVerticalAlign::Bottom);
+        let actual = this.align_to(other, (V::Bottom, H::Middle));
         assert_eq!(actual.to_coords_f32(), (12.5, 5.0, 17.5, 10.0));
 
         // Bottom-right
-        let actual = this.align_to(other, PdfHorizontalAlign::Right, PdfVerticalAlign::Bottom);
+        let actual = this.align_to(other, (V::Bottom, H::Right));
         assert_eq!(actual.to_coords_f32(), (20.0, 5.0, 25.0, 10.0));
     }
 

--- a/src/pdf/object/line.rs
+++ b/src/pdf/object/line.rs
@@ -3,8 +3,8 @@ mod style;
 pub use style::PdfObjectLineStyle;
 
 use crate::pdf::{
-    PdfBounds, PdfColor, PdfContext, PdfLink, PdfLinkAnnotation, PdfLuaExt, PdfLuaTableExt,
-    PdfPoint,
+    PdfAlign, PdfBounds, PdfColor, PdfContext, PdfHorizontalAlign, PdfLink, PdfLinkAnnotation,
+    PdfLuaExt, PdfLuaTableExt, PdfPoint, PdfVerticalAlign,
 };
 use mlua::prelude::*;
 use printpdf::{Line, LineCapStyle, LineDashPattern};
@@ -58,6 +58,23 @@ impl PdfObjectLine {
         }
 
         PdfBounds::new(ll, ur)
+    }
+
+    /// Aligns the line to a set of bounds.
+    pub fn align_to(&mut self, bounds: PdfBounds, align: (PdfVerticalAlign, PdfHorizontalAlign)) {
+        // Get new bounds for series of points
+        let src_bounds = self.bounds();
+        let dst_bounds = src_bounds.align_to(bounds, align);
+
+        // Figure out the shift from original to new bounds
+        let x_offset = dst_bounds.ll.x - src_bounds.ll.x;
+        let y_offset = dst_bounds.ll.y - src_bounds.ll.y;
+
+        // Apply the changes to all of the points
+        for point in self.points.iter_mut() {
+            point.x += x_offset;
+            point.y += y_offset;
+        }
     }
 
     /// Returns a collection of link annotations.
@@ -123,6 +140,16 @@ impl<'lua> IntoLua<'lua> for PdfObjectLine {
         table.raw_set("link", self.link)?;
 
         metatable.raw_set(
+            "align_to",
+            lua.create_function(
+                move |_, (mut this, bounds, align): (Self, PdfBounds, PdfAlign)| {
+                    this.align_to(bounds, align.to_v_h());
+                    Ok(this)
+                },
+            )?,
+        )?;
+
+        metatable.raw_set(
             "bounds",
             lua.create_function(move |_, this: Self| Ok(this.bounds()))?,
         )?;
@@ -158,6 +185,42 @@ mod tests {
     use super::*;
     use crate::pdf::Pdf;
     use mlua::chunk;
+
+    #[test]
+    fn should_be_able_to_align_line_to_some_bounds_in_lua() {
+        // Stand up Lua runtime with everything configured properly for tests
+        let lua = Lua::new();
+        lua.globals().raw_set("pdf", Pdf::default()).unwrap();
+
+        // Test the bounds, which should correctly cover full shape
+        lua.load(chunk! {
+            // Create an initial shape at some position
+            local line = pdf.object.line({
+                { x = 1, y = 5 },
+                { x = 3, y = 4 },
+            })
+
+            // Assert the line is where we expect prior to alignment
+            pdf.utils.assert_deep_equal(line:bounds(), {
+                ll = { x = 1, y = 4 },
+                ur = { x = 3, y = 5 },
+            })
+
+            // Do the alignment with some bounds that are elsewhere
+            line = line:align_to({
+                ll = { x = 5,  y = 5 },
+                ur = { x = 10, y = 10 },
+            }, { v = "bottom", h = "left" })
+
+            // Assert the line has moved into place
+            pdf.utils.assert_deep_equal(line:bounds(), {
+                ll = { x = 5, y = 5 },
+                ur = { x = 7, y = 6 },
+            })
+        })
+        .exec()
+        .expect("Assertion failed");
+    }
 
     #[test]
     fn should_be_able_to_calculate_bounds_of_line() {

--- a/src/pdf/object/text.rs
+++ b/src/pdf/object/text.rs
@@ -1,7 +1,7 @@
 use crate::constants::GLOBAL_PDF_VAR_NAME;
 use crate::pdf::{
-    PdfBounds, PdfColor, PdfConfig, PdfContext, PdfLink, PdfLinkAnnotation, PdfLuaExt,
-    PdfLuaTableExt, PdfPoint,
+    PdfAlign, PdfBounds, PdfColor, PdfConfig, PdfContext, PdfHorizontalAlign, PdfLink,
+    PdfLinkAnnotation, PdfLuaExt, PdfLuaTableExt, PdfPoint, PdfVerticalAlign,
 };
 use crate::runtime::{RuntimeFontId, RuntimeFonts};
 use mlua::prelude::*;
@@ -53,6 +53,26 @@ impl PdfObjectText {
             }],
             None => Vec::new(),
         }
+    }
+
+    /// Aligns the text to a set of bounds.
+    pub fn align_to(
+        &mut self,
+        ctx: PdfContext,
+        bounds: PdfBounds,
+        align: (PdfVerticalAlign, PdfHorizontalAlign),
+    ) {
+        // Get new bounds for the text
+        let src_bounds = self.bounds(ctx);
+        let dst_bounds = src_bounds.align_to(bounds, align);
+
+        // Figure out changes from original bounds of points
+        let x_offset = dst_bounds.width() - src_bounds.width();
+        let y_offset = dst_bounds.height() - src_bounds.height();
+
+        // Apply the changes to the text coordinates
+        self.point.x += x_offset;
+        self.point.y += y_offset;
     }
 
     /// Returns bounds for the text by calculating the width and height and applying to
@@ -111,6 +131,31 @@ impl PdfObjectText {
             Err(LuaError::runtime("Runtime fonts are missing"))
         }
     }
+
+    /// Aligns the text to a set of bounds.
+    ///
+    /// Calculates bounds from a [`Lua`] runtime, which occurs earlier than when a [`PdfContext`]
+    /// is available.
+    pub(crate) fn lua_align_to(
+        &mut self,
+        lua: &Lua,
+        bounds: PdfBounds,
+        align: (PdfVerticalAlign, PdfHorizontalAlign),
+    ) -> LuaResult<()> {
+        // Get new bounds for the text
+        let src_bounds = self.lua_bounds(lua)?;
+        let dst_bounds = src_bounds.align_to(bounds, align);
+
+        // Figure out the shift from original to new bounds
+        let x_offset = dst_bounds.ll.x - src_bounds.ll.x;
+        let y_offset = dst_bounds.ll.y - src_bounds.ll.y;
+
+        // Apply the changes to the text coordinates
+        self.point.x += x_offset;
+        self.point.y += y_offset;
+
+        Ok(())
+    }
 }
 
 fn glyph_metrics(face: &Face, glyph_id: u16) -> Option<GlyphMetrics> {
@@ -141,9 +186,16 @@ impl<'lua> IntoLua<'lua> for PdfObjectText {
         table.raw_set("outline_color", self.outline_color)?;
         table.raw_set("link", self.link)?;
 
-        // Add specialized methods to calculate the bounds, width, and height of the text
-        // by looking up the global config, grabbing the default font size, and accessing
-        // the repository of fonts to get the information needed for the current text.
+        metatable.raw_set(
+            "align_to",
+            lua.create_function(
+                move |lua, (mut this, bounds, align): (Self, PdfBounds, PdfAlign)| {
+                    this.lua_align_to(lua, bounds, align.to_v_h())?;
+                    Ok(this)
+                },
+            )?,
+        )?;
+
         metatable.raw_set(
             "bounds",
             lua.create_function(move |lua, this: Self| this.lua_bounds(lua))?,
@@ -255,6 +307,49 @@ mod tests {
     use crate::runtime::RuntimeFonts;
     use mlua::chunk;
     use printpdf::{Mm, PdfDocument};
+
+    #[test]
+    fn should_be_able_to_align_text_to_some_bounds_in_lua() {
+        // Stand up Lua runtime with everything configured properly for tests
+        let lua = Lua::new();
+        lua.globals().raw_set("pdf", Pdf::default()).unwrap();
+        lua.set_app_data({
+            let mut fonts = RuntimeFonts::new();
+            let id = fonts.add_builtin_font().unwrap();
+            fonts.add_font_as_fallback(id);
+            fonts
+        });
+
+        // Test the bounds, which should correctly cover full text
+        lua.load(chunk! {
+            local text = pdf.object.text({
+                x = 0,
+                y = 0,
+                text = "hello world",
+                size = 36.0,
+            })
+
+            // Assert the text is where we expect prior to alignment
+            pdf.utils.assert_deep_equal(text:bounds(), {
+                ll = { x = 0,                   y = -3.810002326965332 },
+                ur = { x = 83.82005310058594,   y = 12.954007148742676 },
+            })
+
+            // Do the alignment with some bounds that are elsewhere
+            text = text:align_to({
+                ll = { x = 5,  y = 5 },
+                ur = { x = 10, y = 10 },
+            }, { v = "bottom", h = "left" })
+
+            // Assert the text has moved into place
+            pdf.utils.assert_deep_equal(text:bounds(), {
+                ll = { x = 5,                   y = 5 },
+                ur = { x = 88.82005310058594,   y = 21.764009475708008 },
+            })
+        })
+        .exec()
+        .expect("Assertion failed");
+    }
 
     #[test]
     fn should_be_able_to_calculate_bounds_of_text() {


### PR DESCRIPTION

Summary: Implements a Lua function on each object to support aligning to another object.

Test Plan: `cargo test`
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/chipsenkbeil/makepdf/pull/13).
* #16
* #15
* #14
* __->__ #13