### PR TITLE
Add Lua conversion tests for objects

### DIFF
--- a/src/pdf/common/link.rs
+++ b/src/pdf/common/link.rs
@@ -11,7 +11,7 @@ pub struct PdfLinkAnnotation {
 }
 
 /// Represents an action to take as a link.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PdfLink {
     /// Link should go to an internal page denoted by the page's id.
     GoTo { page: u32 },

--- a/src/pdf/common/mode.rs
+++ b/src/pdf/common/mode.rs
@@ -5,6 +5,28 @@ use printpdf::path::PaintMode;
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct PdfPaintMode(PaintMode);
 
+impl PdfPaintMode {
+    #[inline]
+    pub const fn clip() -> Self {
+        Self(PaintMode::Clip)
+    }
+
+    #[inline]
+    pub const fn fill() -> Self {
+        Self(PaintMode::Fill)
+    }
+
+    #[inline]
+    pub const fn fill_stroke() -> Self {
+        Self(PaintMode::FillStroke)
+    }
+
+    #[inline]
+    pub const fn stroke() -> Self {
+        Self(PaintMode::Stroke)
+    }
+}
+
 impl From<PdfPaintMode> for PaintMode {
     fn from(mode: PdfPaintMode) -> Self {
         mode.0
@@ -30,10 +52,10 @@ impl<'lua> FromLua<'lua> for PdfPaintMode {
         let from = value.type_name();
         match value {
             LuaValue::String(s) => match s.to_string_lossy().as_ref() {
-                "clip" => Ok(Self(PaintMode::Clip)),
-                "fill" => Ok(Self(PaintMode::Fill)),
-                "fill_stroke" => Ok(Self(PaintMode::FillStroke)),
-                "stroke" => Ok(Self(PaintMode::Stroke)),
+                "clip" => Ok(Self::clip()),
+                "fill" => Ok(Self::fill()),
+                "fill_stroke" => Ok(Self::fill_stroke()),
+                "stroke" => Ok(Self::stroke()),
                 ty => Err(LuaError::FromLuaConversionError {
                     from,
                     to: "pdf.common.paint_mode",

--- a/src/pdf/common/order.rs
+++ b/src/pdf/common/order.rs
@@ -5,6 +5,18 @@ use printpdf::path::WindingOrder;
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct PdfWindingOrder(WindingOrder);
 
+impl PdfWindingOrder {
+    #[inline]
+    pub const fn even_odd() -> Self {
+        Self(WindingOrder::EvenOdd)
+    }
+
+    #[inline]
+    pub const fn non_zero() -> Self {
+        Self(WindingOrder::NonZero)
+    }
+}
+
 impl From<PdfWindingOrder> for WindingOrder {
     fn from(order: PdfWindingOrder) -> Self {
         order.0
@@ -28,8 +40,8 @@ impl<'lua> FromLua<'lua> for PdfWindingOrder {
         let from = value.type_name();
         match value {
             LuaValue::String(s) => match s.to_string_lossy().as_ref() {
-                "even_odd" => Ok(Self(WindingOrder::EvenOdd)),
-                "non_zero" => Ok(Self(WindingOrder::NonZero)),
+                "even_odd" => Ok(Self::even_odd()),
+                "non_zero" => Ok(Self::non_zero()),
                 ty => Err(LuaError::FromLuaConversionError {
                     from,
                     to: "pdf.common.winding_order",

--- a/src/pdf/object.rs
+++ b/src/pdf/object.rs
@@ -15,7 +15,7 @@ pub use text::PdfObjectText;
 use crate::pdf::{PdfBounds, PdfContext, PdfLinkAnnotation, PdfLuaTableExt};
 use mlua::prelude::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum PdfObject {
     Group(PdfObjectGroup),
     Line(PdfObjectLine),


### PR DESCRIPTION

Summary: Adds IntoLua and FromLua conversion tests for group, line, rect, shape, and text objects.

Test Plan: `cargo test`
