### PR TITLE
Consolidate colors

### DIFF
--- a/assets/scripts/definitions.lua
+++ b/assets/scripts/definitions.lua
@@ -14,23 +14,33 @@ pdf = {}
 
 ---@class pdf.page
 pdf.page = {
+    ---DPI of the page.
     ---@type number
     dpi = 0,
-    --@type string|nil
+    ---Path to an external font to load as the default font.
+    ---If none provided, uses builtin font.
+    ---@type string|nil
     font = "",
-    --@type number
+    ---Width of the page in millimeters.
+    ---@type number
     width = 0,
-    --@type number
+    ---Height of the page in millimeters.
+    ---@type number
     height = 0,
-    --@type number
+    ---Default size of text font in points.
+    ---@type number
     font_size = 0,
-    --@type pdf.common.Color
+    ---Used for the interior of rects and shapes, and for text.
+    ---@type pdf.common.Color
     fill_color = "",
-    --@type pdf.common.Color
+    ---Used for the exterior of rects and shapes, and for lines.
+    ---@type pdf.common.Color
     outline_color = "",
-    --@type number
+    ---Default thickness of lines.
+    ---@type number
     outline_thickness = 0,
-    --@type pdf.object.line.Style
+    ---Default style of lines.
+    ---@type pdf.object.line.Style
     line_style = "solid",
 }
 
@@ -312,9 +322,7 @@ local PdfObjectLine = {
     ---@type integer|nil
     depth = nil,
     ---@type pdf.common.Color|nil
-    fill_color = nil,
-    ---@type pdf.common.Color|nil
-    outline_color = nil,
+    color = nil,
     ---@type number|nil
     thickness = nil,
     ---@type pdf.object.line.Style|nil
@@ -339,9 +347,7 @@ local PdfObjectLineArgs = {
     ---@type integer|nil
     depth = nil,
     ---@type pdf.common.Color|nil
-    fill_color = nil,
-    ---@type pdf.common.Color|nil
-    outline_color = nil,
+    color = nil,
     ---@type number|nil
     thickness = nil,
     ---@type pdf.object.line.Style|nil
@@ -497,9 +503,7 @@ local PdfObjectText = {
     ---@type number|nil
     size = nil,
     ---@type pdf.common.Color|nil
-    fill_color = nil,
-    ---@type pdf.common.Color|nil
-    outline_color = nil,
+    color = nil,
     ---@type pdf.common.Link|nil
     link = nil,
 }
@@ -530,9 +534,7 @@ local PdfObjectTextArgsBase = {
     ---@type number|nil
     size = nil,
     ---@type pdf.common.Color|nil
-    fill_color = nil,
-    ---@type pdf.common.Color|nil
-    outline_color = nil,
+    color = nil,
     ---@type pdf.common.LinkArg|nil
     link = nil,
 }

--- a/src/pdf/object/line.rs
+++ b/src/pdf/object/line.rs
@@ -14,8 +14,7 @@ use printpdf::{Line, LineCapStyle, LineDashPattern};
 pub struct PdfObjectLine {
     pub points: Vec<PdfPoint>,
     pub depth: Option<i64>,
-    pub fill_color: Option<PdfColor>,
-    pub outline_color: Option<PdfColor>,
+    pub color: Option<PdfColor>,
     pub thickness: Option<f32>,
     pub style: Option<PdfObjectLineStyle>,
     pub link: Option<PdfLink>,
@@ -92,13 +91,11 @@ impl PdfObjectLine {
     /// Draws the object within the PDF.
     pub fn draw(&self, ctx: PdfContext<'_>) {
         // Get optional values, setting defaults when not specified
-        let fill_color = self.fill_color.unwrap_or(ctx.config.page.fill_color);
-        let outline_color = self.fill_color.unwrap_or(ctx.config.page.outline_color);
+        let outline_color = self.color.unwrap_or(ctx.config.page.outline_color);
         let thickness = self.thickness.unwrap_or(ctx.config.page.outline_thickness);
         let style = self.style.unwrap_or(ctx.config.page.line_style);
 
         // Set the color and thickness of our line
-        ctx.layer.set_fill_color(fill_color.into());
         ctx.layer.set_outline_color(outline_color.into());
         ctx.layer.set_outline_thickness(thickness);
 
@@ -134,8 +131,7 @@ impl<'lua> IntoLua<'lua> for PdfObjectLine {
         // Add properties as extra named fields
         table.raw_set("type", PdfObjectType::Line)?;
         table.raw_set("depth", self.depth)?;
-        table.raw_set("fill_color", self.fill_color)?;
-        table.raw_set("outline_color", self.outline_color)?;
+        table.raw_set("color", self.color)?;
         table.raw_set("thickness", self.thickness)?;
         table.raw_set("style", self.style)?;
         table.raw_set("link", self.link)?;
@@ -166,8 +162,7 @@ impl<'lua> FromLua<'lua> for PdfObjectLine {
             LuaValue::Table(table) => Ok(Self {
                 points: table.clone().sequence_values().collect::<LuaResult<_>>()?,
                 depth: table.raw_get_ext("depth")?,
-                fill_color: table.raw_get_ext("fill_color")?,
-                outline_color: table.raw_get_ext("outline_color")?,
+                color: table.raw_get_ext("color")?,
                 thickness: table.raw_get_ext("thickness")?,
                 style: table.raw_get_ext("style")?,
                 link: table.raw_get_ext("link")?,
@@ -306,8 +301,7 @@ mod tests {
             Lua::new()
                 .load(chunk!({
                     depth = 123,
-                    fill_color = "123456",
-                    outline_color = "789ABC",
+                    color = "123456",
                     thickness = 456,
                     style = "dashed",
                     link = {
@@ -320,8 +314,7 @@ mod tests {
             PdfObjectLine {
                 points: Vec::new(),
                 depth: Some(123),
-                fill_color: Some("#123456".parse().unwrap()),
-                outline_color: Some("#789ABC".parse().unwrap()),
+                color: Some("#123456".parse().unwrap()),
                 thickness: Some(456.0),
                 style: Some(PdfObjectLineStyle::Dashed),
                 link: Some(PdfLink::Uri {
@@ -355,8 +348,7 @@ mod tests {
                     { x = 1, y = 2 },
                     { x = 3, y = 4 },
                     depth = 123,
-                    fill_color = "123456",
-                    outline_color = "789ABC",
+                    color = "123456",
                     thickness = 456,
                     style = "dashed",
                     link = {
@@ -372,8 +364,7 @@ mod tests {
                     PdfPoint::from_coords_f32(3.0, 4.0),
                 ],
                 depth: Some(123),
-                fill_color: Some("#123456".parse().unwrap()),
-                outline_color: Some("#789ABC".parse().unwrap()),
+                color: Some("#123456".parse().unwrap()),
                 thickness: Some(456.0),
                 style: Some(PdfObjectLineStyle::Dashed),
                 link: Some(PdfLink::Uri {
@@ -407,8 +398,7 @@ mod tests {
                 PdfPoint::from_coords_f32(3.0, 4.0),
             ],
             depth: Some(123),
-            fill_color: Some("#123456".parse().unwrap()),
-            outline_color: Some("#789ABC".parse().unwrap()),
+            color: Some("#123456".parse().unwrap()),
             thickness: Some(456.0),
             style: Some(PdfObjectLineStyle::Dashed),
             link: Some(PdfLink::Uri {
@@ -422,8 +412,7 @@ mod tests {
                 { x = 3, y = 4 },
                 type = "line",
                 depth = 123,
-                fill_color = "123456",
-                outline_color = "789ABC",
+                color = "123456",
                 thickness = 456,
                 style = "dashed",
                 link = {

--- a/src/pdf/object/text.rs
+++ b/src/pdf/object/text.rs
@@ -16,8 +16,7 @@ pub struct PdfObjectText {
     pub depth: Option<i64>,
     pub font: Option<RuntimeFontId>,
     pub size: Option<f32>,
-    pub fill_color: Option<PdfColor>,
-    pub outline_color: Option<PdfColor>,
+    pub color: Option<PdfColor>,
     pub link: Option<PdfLink>,
 }
 
@@ -26,8 +25,7 @@ impl PdfObjectText {
     pub fn draw(&self, ctx: PdfContext) {
         // Get optional values, setting defaults when not specified
         let size = self.size.unwrap_or(ctx.config.page.font_size);
-        let fill_color = self.fill_color.unwrap_or(ctx.config.page.fill_color);
-        let outline_color = self.outline_color.unwrap_or(ctx.config.page.outline_color);
+        let fill_color = self.color.unwrap_or(ctx.config.page.fill_color);
         let (x, y) = self.point.to_coords();
 
         // Retrieve the font to use for the text, leveraging the configured font first, otherwise
@@ -38,7 +36,6 @@ impl PdfObjectText {
             .or_else(|| ctx.fonts.get_font_doc_ref(ctx.fallback_font_id))
         {
             ctx.layer.set_fill_color(fill_color.into());
-            ctx.layer.set_outline_color(outline_color.into());
             ctx.layer.use_text(&self.text, size, x, y, font_ref);
         }
     }
@@ -183,8 +180,7 @@ impl<'lua> IntoLua<'lua> for PdfObjectText {
         table.raw_set("size", self.size)?;
         table.raw_set("depth", self.depth)?;
         table.raw_set("font", self.font)?;
-        table.raw_set("fill_color", self.fill_color)?;
-        table.raw_set("outline_color", self.outline_color)?;
+        table.raw_set("color", self.color)?;
         table.raw_set("link", self.link)?;
 
         metatable.raw_set(
@@ -235,8 +231,7 @@ impl<'lua> FromLua<'lua> for PdfObjectText {
                     size: table.raw_get_ext("size")?,
                     depth: table.raw_get_ext("depth")?,
                     font: table.raw_get_ext("font")?,
-                    fill_color: table.raw_get_ext("fill_color")?,
-                    outline_color: table.raw_get_ext("outline_color")?,
+                    color: table.raw_get_ext("color")?,
                     link: table.raw_get_ext("link")?,
                 })
             }
@@ -457,8 +452,7 @@ mod tests {
                     depth = 123,
                     font = 456,
                     size = 789,
-                    fill_color = "123456",
-                    outline_color = "789ABC",
+                    color = "123456",
                     link = {
                         type = "uri",
                         uri = "https://example.com",
@@ -472,8 +466,7 @@ mod tests {
                 depth: Some(123),
                 font: Some(456),
                 size: Some(789.0),
-                fill_color: Some("#123456".parse().unwrap()),
-                outline_color: Some("#789ABC".parse().unwrap()),
+                color: Some("#123456".parse().unwrap()),
                 link: Some(PdfLink::Uri {
                     uri: String::from("https://example.com"),
                 }),
@@ -508,8 +501,7 @@ mod tests {
             depth: Some(123),
             font: Some(456),
             size: Some(789.0),
-            fill_color: Some("#123456".parse().unwrap()),
-            outline_color: Some("#789ABC".parse().unwrap()),
+            color: Some("#123456".parse().unwrap()),
             link: Some(PdfLink::Uri {
                 uri: String::from("https://example.com"),
             }),
@@ -524,8 +516,7 @@ mod tests {
                 depth = 123,
                 font = 456,
                 size = 789,
-                fill_color = "123456",
-                outline_color = "789ABC",
+                color = "123456",
                 link = {
                     type = "uri",
                     uri = "https://example.com",


### PR DESCRIPTION

Summary: Consolidates colors for line and text to use outline and fill only, respectively. Also fix a documentation issue in definitions.

Test Plan:  `cargo test`
