### PR TITLE
Expose bounds() on pdf.utils

### DIFF
--- a/src/pdf/utils.rs
+++ b/src/pdf/utils.rs
@@ -1,4 +1,4 @@
-use crate::pdf::PdfLuaExt;
+use crate::pdf::{PdfBounds, PdfLuaExt};
 use mlua::prelude::*;
 use tailcall::tailcall;
 
@@ -150,6 +150,11 @@ impl<'lua> IntoLua<'lua> for PdfUtils {
                     .unwrap_or(false);
                 PdfUtils::try_assert_deep_equal(a, b, false, ignore_metatable)
             })?,
+        )?;
+
+        metatable.raw_set(
+            "bounds",
+            lua.create_function(|_, bounds: PdfBounds| Ok(bounds))?,
         )?;
 
         metatable.raw_set(


### PR DESCRIPTION

Summary: Exposes `pdf.utils.bounds()` to create a bounds table.

Test Plan: N/A
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/chipsenkbeil/makepdf/pull/20).
* #22
* #23
* #21
* __->__ #20