### PR TITLE
Add PdfDateWeekday and additional tests for PdfDate

### DIFF
--- a/assets/scripts/definitions.lua
+++ b/assets/scripts/definitions.lua
@@ -137,6 +137,10 @@ PdfDate.month = 0
 ---@type integer
 PdfDate.week = 0
 
+---Weekday associated with the date.
+---@type pdf.common.DateWeekday
+PdfDate.weekday = {}
+
 ---Between 1 and 31
 ---@type integer
 PdfDate.day = 0
@@ -181,6 +185,78 @@ function PdfDate.next_month() end
 
 ---@return pdf.common.Date|nil
 function PdfDate.last_month() end
+
+---@return pdf.common.Date|nil
+function PdfDate.beginning_of_year() end
+
+---@return pdf.common.Date|nil
+function PdfDate.end_of_year() end
+
+---@return pdf.common.Date|nil
+function PdfDate.beginning_of_month() end
+
+---@return pdf.common.Date|nil
+function PdfDate.end_of_month() end
+
+---Returns current date moved to beginning of week where beginning of week starts on Sunday.
+---@return pdf.common.Date|nil
+function PdfDate.beginning_of_week_sunday() end
+
+---Returns current date moved to end of week where beginning of week starts on Sunday.
+---@return pdf.common.Date|nil
+function PdfDate.end_of_week_sunday() end
+
+---Returns current date moved to beginning of week where beginning of week starts on Monday.
+---@return pdf.common.Date|nil
+function PdfDate.beginning_of_week_monday() end
+
+---Returns current date moved to end of week where beginning of week starts on Monday.
+---@return pdf.common.Date|nil
+function PdfDate.end_of_week_monday() end
+
+---@class pdf.common.DateWeekday
+local PdfDateWeekday = {}
+
+---Returns the short name of the weekday.
+---@return "mon"|"tue"|"wed"|"thu"|"fri"|"sat"|"sun"
+function PdfDateWeekday.short_name() end
+
+---Returns the short name of the weekday.
+---@return "monday"|"tuesday"|"wednesday"|"thursday"|"friday"|"saturday"|"sunday"
+function PdfDateWeekday.long_name() end
+
+---Returns next day of the week.
+---@return pdf.common.DateWeekday
+function PdfDateWeekday.next_weekday() end
+
+---Returns previous day of the week.
+---@return pdf.common.DateWeekday
+function PdfDateWeekday.prev_weekday() end
+
+---Returns a day-of-week number starting from Monday = 1.
+---(ISO 8601 weekday number)
+---@return integer
+function PdfDateWeekday.number_from_monday() end
+
+---Returns a day-of-week number starting from Sunday = 1.
+---@return integer
+function PdfDateWeekday.number_from_sunday() end
+
+---Returns a day-of-week number starting from Monday = 0.
+---@return integer
+function PdfDateWeekday.num_days_from_monday() end
+
+---Returns a day-of-week number starting from Sunday = 0.
+---@return integer
+function PdfDateWeekday.num_days_from_sunday() end
+
+---Returns number of days from specified `weekday`.
+---
+---For example, if this weekday is Monday, and the specified `weekday`
+---is Wednesday, this would return 2.
+---@param weekday pdf.common.DateWeekday
+---@return integer
+function PdfDateWeekday.days_since(weekday) end
 
 -------------------------------------------------------------------------------
 -- RUNTIME TYPES

--- a/src/pdf/common/date.rs
+++ b/src/pdf/common/date.rs
@@ -1,3 +1,7 @@
+mod weekday;
+
+pub use weekday::PdfDateWeekday;
+
 use crate::pdf::{PdfLuaExt, PdfLuaTableExt};
 use chrono::prelude::*;
 use chrono::Datelike;
@@ -16,8 +20,13 @@ impl PdfDate {
     /// Returns the year associated with the date.
     ///
     /// Negatives represent BCE. e.g. -309 == 308 BCE.
-    pub fn year(&self) -> i32 {
+    pub fn year(self) -> i32 {
         self.0.year()
+    }
+
+    /// Returns the weekday associated with the date.
+    pub fn weekday(self) -> PdfDateWeekday {
+        self.0.weekday().into()
     }
 
     /// Creates a new date for beginning of `year`. Returns None if invalid.
@@ -25,14 +34,66 @@ impl PdfDate {
         NaiveDate::from_ymd_opt(year, 1, 1).map(PdfDate)
     }
 
+    /// Returns a new date representing beginning of the year for current date.
+    pub fn into_beginning_of_year(self) -> Self {
+        Self::beginning_of_year(self.year()).unwrap()
+    }
+
     /// Creates a new date for end of `year`. Returns None if invalid.
     pub fn end_of_year(year: i32) -> Option<Self> {
         NaiveDate::from_ymd_opt(year, 12, 31).map(PdfDate)
     }
 
-    /// Creates a new date for `year` and `month`. Returns None if invalid.
+    /// Returns a new date representing end of the year for current date.
+    pub fn into_end_of_year(self) -> Self {
+        Self::end_of_year(self.year()).unwrap()
+    }
+
+    /// Creates a new date for `year` at beginning of `month`. Returns None if invalid.
     pub fn beginning_of_month(year: i32, month: u32) -> Option<Self> {
         NaiveDate::from_ymd_opt(year, month, 1).map(PdfDate)
+    }
+
+    /// Returns a new date representing beginning of month for current date.
+    pub fn into_beginning_of_month(self) -> Self {
+        Self::beginning_of_month(self.year(), self.month()).unwrap()
+    }
+
+    /// Creates a new date for `year` at end of `month`. Returns None if invalid.
+    pub fn end_of_month(year: i32, month: u32) -> Option<Self> {
+        // Go to beginning of this month, advance a month, and then get yesterday
+        Self::beginning_of_month(year, month)?
+            .next_month()?
+            .yesterday()
+    }
+
+    /// Returns a new date representing end of month for current date.
+    pub fn into_end_of_month(self) -> Self {
+        Self::end_of_month(self.year(), self.month()).unwrap()
+    }
+
+    /// Returns a new date representing beginning of week (Sunday-based) for current date.
+    pub fn into_beginning_of_week_sunday(self) -> Self {
+        let weekday = self.weekday();
+        let num_days = weekday.num_days_from_sunday();
+        self.add_days(-(num_days as i64)).unwrap()
+    }
+
+    /// Returns a new date representing end of week (Sunday-based) for current date.
+    pub fn into_end_of_week_sunday(self) -> Self {
+        self.into_beginning_of_week_sunday().add_days(6).unwrap()
+    }
+
+    /// Returns a new date representing beginning of week (Monday-based) for current date.
+    pub fn into_beginning_of_week_monday(self) -> Self {
+        let weekday = self.weekday();
+        let num_days = weekday.num_days_from_monday();
+        self.add_days(-(num_days as i64)).unwrap()
+    }
+
+    /// Returns a new date representing end of week (Monday-based) for current date.
+    pub fn into_end_of_week_monday(self) -> Self {
+        self.into_beginning_of_week_monday().add_days(6).unwrap()
     }
 
     /// Adds days to the date, returning the new date or none if the date would be out of range.
@@ -158,6 +219,7 @@ impl<'lua> IntoLua<'lua> for PdfDate {
         table.raw_set("day", self.0.day())?;
 
         table.raw_set("week", self.0.iso_week().week())?;
+        table.raw_set("weekday", self.weekday())?;
         table.raw_set("ordinal", self.0.ordinal())?;
 
         metatable.raw_set(
@@ -240,6 +302,46 @@ impl<'lua> IntoLua<'lua> for PdfDate {
         )?;
 
         metatable.raw_set(
+            "beginning_of_year",
+            lua.create_function(move |_, ()| Ok(self.into_beginning_of_year()))?,
+        )?;
+
+        metatable.raw_set(
+            "end_of_year",
+            lua.create_function(move |_, ()| Ok(self.into_end_of_year()))?,
+        )?;
+
+        metatable.raw_set(
+            "beginning_of_month",
+            lua.create_function(move |_, ()| Ok(self.into_beginning_of_month()))?,
+        )?;
+
+        metatable.raw_set(
+            "end_of_month",
+            lua.create_function(move |_, ()| Ok(self.into_end_of_month()))?,
+        )?;
+
+        metatable.raw_set(
+            "beginning_of_week_sunday",
+            lua.create_function(move |_, ()| Ok(self.into_beginning_of_week_sunday()))?,
+        )?;
+
+        metatable.raw_set(
+            "end_of_week_sunday",
+            lua.create_function(move |_, ()| Ok(self.into_end_of_week_sunday()))?,
+        )?;
+
+        metatable.raw_set(
+            "beginning_of_week_monday",
+            lua.create_function(move |_, ()| Ok(self.into_beginning_of_week_monday()))?,
+        )?;
+
+        metatable.raw_set(
+            "end_of_week_monday",
+            lua.create_function(move |_, ()| Ok(self.into_end_of_week_monday()))?,
+        )?;
+
+        metatable.raw_set(
             "__eq",
             lua.create_function(|_, (a, b): (PdfDate, PdfDate)| Ok(a.0 == b.0))?,
         )?;
@@ -308,6 +410,785 @@ mod tests {
     use mlua::chunk;
 
     #[test]
+    fn should_be_able_to_format_in_lua() {
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.format("%B")))
+                .eval::<String>()
+                .unwrap(),
+            "September",
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_add_days_in_lua() {
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+
+        // Test advancing a single day within same month
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_days(1)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 15).unwrap()),
+        );
+
+        // Test backtracking a single day within same month
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_days(-1)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 13).unwrap()),
+        );
+
+        // Test advancing to end of same month
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_days(16)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 30).unwrap()),
+        );
+
+        // Test backtracking to beginning of same month
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_days(-13)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 1).unwrap()),
+        );
+
+        // Test advancing to next month
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_days(17)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 10, 1).unwrap()),
+        );
+
+        // Test backtracking to previous month
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_days(-14)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 8, 31).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_add_weeks_in_lua() {
+        // Test advancing within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_weeks(1)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 21).unwrap()),
+        );
+
+        // Test backtracking within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_weeks(-1)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 7).unwrap()),
+        );
+
+        // Test advancing to next month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 10, 25).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_weeks(1)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 11, 1).unwrap()),
+        );
+
+        // Test backtracking to last month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 10, 7).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_weeks(-1)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 30).unwrap()),
+        );
+
+        // Test advancing to next year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 12, 25).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_weeks(1)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap()),
+        );
+
+        // Test backtracking to previous year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 1, 7).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_weeks(-1)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2023, 12, 31).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_next_week_in_lua() {
+        // Test advancing within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.next_week()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 21).unwrap()),
+        );
+
+        // Test advancing to next month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 10, 25).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.next_week()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 11, 1).unwrap()),
+        );
+
+        // Test advancing to next year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 12, 25).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.next_week()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_last_week_in_lua() {
+        // Test backtracking within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.last_week()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 7).unwrap()),
+        );
+
+        // Test backtracking to last month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 10, 7).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.last_week()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 30).unwrap()),
+        );
+
+        // Test backtracking to previous year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 1, 7).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.last_week()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2023, 12, 31).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_add_months_in_lua() {
+        // Test advancing a single month within same year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_months(1)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 10, 14).unwrap()),
+        );
+
+        // Test backtracking a single month within same year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_months(-1)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 8, 14).unwrap()),
+        );
+
+        // Test advancing a month that is shorter than current month (Oct 31 -> Nov 30)
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 10, 31).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_months(1)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 11, 30).unwrap()),
+        );
+
+        // Test backtracking to a month that is shorter than the current month (Oct 31 -> Sept 30)
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 10, 31).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_months(-1)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 30).unwrap()),
+        );
+
+        // Test advancing to next year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 12, 18).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_months(1)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2025, 1, 18).unwrap()),
+        );
+
+        // Test backtracking to previous year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 1, 18).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.add_months(-1)))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2023, 12, 18).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_next_month_in_lua() {
+        // Test advancing to next month within same year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.next_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 10, 14).unwrap()),
+        );
+
+        // Test advancing to next month that is shorter than current month (Oct 31 -> Nov 30)
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 10, 31).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.next_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 11, 30).unwrap()),
+        );
+
+        // Test advancing to next year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 12, 18).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.next_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2025, 1, 18).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_last_month_in_lua() {
+        // Test backtracking to last month within same year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.last_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 8, 14).unwrap()),
+        );
+
+        // Test backtracking to last month that is shorter than the current month (Oct 31 -> Sept 30)
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 10, 31).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.last_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 30).unwrap()),
+        );
+
+        // Test backtracking to previous year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 1, 18).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.last_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2023, 12, 18).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_tomorrow_in_lua() {
+        // From middle of a month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.tomorrow()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 15).unwrap()),
+        );
+
+        // From end of a month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 30).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.tomorrow()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 10, 1).unwrap()),
+        );
+
+        // From end of a year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 12, 31).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.tomorrow()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_yesterday_in_lua() {
+        // From middle of a month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.yesterday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 13).unwrap()),
+        );
+
+        // From beginning of a month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 10, 1).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.yesterday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 30).unwrap()),
+        );
+
+        // From beginning of a year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.yesterday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2023, 12, 31).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_beginning_of_year_in_lua() {
+        // From middle of a month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_year()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap()),
+        );
+
+        // From beginning of year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_year()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap()),
+        );
+
+        // From end of year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 12, 31).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_year()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_end_of_year_in_lua() {
+        // From middle of a month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_year()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 12, 31).unwrap()),
+        );
+
+        // From beginning of year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_year()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 12, 31).unwrap()),
+        );
+
+        // From end of year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 12, 31).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_year()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 12, 31).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_beginning_of_month_in_lua() {
+        // From middle of a month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 1).unwrap()),
+        );
+
+        // From beginning of a month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 1).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 1).unwrap()),
+        );
+
+        // From end of a month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 30).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 1).unwrap()),
+        );
+
+        // From beginning of year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap()),
+        );
+
+        // From end of year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 12, 31).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 12, 1).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_end_of_month_in_lua() {
+        // From middle of a month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 30).unwrap()),
+        );
+
+        // From beginning of a month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 1).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 30).unwrap()),
+        );
+
+        // From end of a month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 30).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 30).unwrap()),
+        );
+
+        // From beginning of year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 1, 31).unwrap()),
+        );
+
+        // From end of year
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 12, 31).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_month()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 12, 31).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_beginning_of_week_sunday_in_lua() {
+        // From a Sunday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 8).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_week_sunday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 8).unwrap()),
+        );
+
+        // From a Monday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 9).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_week_sunday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 8).unwrap()),
+        );
+
+        // From a Tuesday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 10).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_week_sunday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 8).unwrap()),
+        );
+
+        // From a Saturday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_week_sunday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 8).unwrap()),
+        );
+
+        // From a date that will result in going to the previous month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 10, 1).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_week_sunday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 29).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_end_of_week_sunday_in_lua() {
+        // From a Sunday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 8).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_week_sunday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap()),
+        );
+
+        // From a Monday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 9).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_week_sunday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap()),
+        );
+
+        // From a Tuesday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 10).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_week_sunday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap()),
+        );
+
+        // From a Saturday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_week_sunday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap()),
+        );
+
+        // From a date that will result in going to the next month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 30).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_week_sunday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 10, 5).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_beginning_of_week_monday_in_lua() {
+        // From a Sunday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 8).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_week_monday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 2).unwrap()),
+        );
+
+        // From a Monday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 9).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_week_monday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 9).unwrap()),
+        );
+
+        // From a Tuesday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 10).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_week_monday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 9).unwrap()),
+        );
+
+        // From a Saturday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_week_monday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 9).unwrap()),
+        );
+
+        // From a date that will result in going to the previous month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 10, 1).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.beginning_of_week_monday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 30).unwrap()),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_end_of_week_monday_in_lua() {
+        // From a Sunday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 8).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_week_monday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 8).unwrap()),
+        );
+
+        // From a Monday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 9).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_week_monday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 15).unwrap()),
+        );
+
+        // From a Tuesday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 10).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_week_monday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 15).unwrap()),
+        );
+
+        // From a Saturday within same month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_week_monday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 9, 15).unwrap()),
+        );
+
+        // From a date that will result in going to the next month
+        let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 30).unwrap());
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($date.end_of_week_monday()))
+                .eval::<PdfDate>()
+                .unwrap(),
+            PdfDate(NaiveDate::from_ymd_opt(2024, 10, 6).unwrap()),
+        );
+    }
+
+    #[test]
     fn should_be_able_to_convert_from_lua() {
         // Create date 2024/09/14 (September 14th, 2024)
         let date = PdfDate(NaiveDate::from_ymd_opt(2024, 9, 14).unwrap());
@@ -349,12 +1230,8 @@ mod tests {
                     month = 9,
                     day = 14,
                     week = 37,
+                    weekday = {}, // NOTE: Everything is in a metatable here.
                     ordinal = 258,
-
-                    // NOTE: Deep equality check will include added field methods, so
-                    //       we just copy these from the converted value for this to pass!
-                    add_days = date.add_days,
-                    add_months = date.add_months,
                 }, {ignore_metatable = true})
             })
             .exec()

--- a/src/pdf/common/date/weekday.rs
+++ b/src/pdf/common/date/weekday.rs
@@ -1,0 +1,590 @@
+use crate::pdf::{PdfLuaExt, PdfLuaTableExt};
+use chrono::Weekday;
+use mlua::prelude::*;
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+use std::str::FromStr;
+
+/// Weekday associated with a PDF date.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct PdfDateWeekday(Weekday);
+
+impl PdfDateWeekday {
+    #[inline]
+    pub const fn monday() -> Self {
+        Self(Weekday::Mon)
+    }
+
+    #[inline]
+    pub const fn tuesday() -> Self {
+        Self(Weekday::Tue)
+    }
+
+    #[inline]
+    pub const fn wednesday() -> Self {
+        Self(Weekday::Wed)
+    }
+
+    #[inline]
+    pub const fn thursday() -> Self {
+        Self(Weekday::Thu)
+    }
+
+    #[inline]
+    pub const fn friday() -> Self {
+        Self(Weekday::Fri)
+    }
+
+    #[inline]
+    pub const fn saturday() -> Self {
+        Self(Weekday::Sat)
+    }
+
+    #[inline]
+    pub const fn sunday() -> Self {
+        Self(Weekday::Sun)
+    }
+
+    /// Returns a static string in the short form for a weekday.
+    ///
+    /// For example, Sunday would return `sun`.
+    #[inline]
+    pub const fn into_short_static_str(self) -> &'static str {
+        match self.0 {
+            Weekday::Mon => "mon",
+            Weekday::Tue => "tue",
+            Weekday::Wed => "wed",
+            Weekday::Thu => "thu",
+            Weekday::Fri => "fri",
+            Weekday::Sat => "sat",
+            Weekday::Sun => "sun",
+        }
+    }
+
+    /// Returns a static string in the long form for a weekday.
+    ///
+    /// For example, Sunday would return `sunday`.
+    #[inline]
+    pub const fn into_long_static_str(self) -> &'static str {
+        match self.0 {
+            Weekday::Mon => "monday",
+            Weekday::Tue => "tuesday",
+            Weekday::Wed => "wednesday",
+            Weekday::Thu => "thursday",
+            Weekday::Fri => "friday",
+            Weekday::Sat => "saturday",
+            Weekday::Sun => "sunday",
+        }
+    }
+}
+
+impl Deref for PdfDateWeekday {
+    type Target = Weekday;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for PdfDateWeekday {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<Weekday> for PdfDateWeekday {
+    fn from(weekday: Weekday) -> Self {
+        Self(weekday)
+    }
+}
+
+impl From<PdfDateWeekday> for Weekday {
+    fn from(weekday: PdfDateWeekday) -> Self {
+        weekday.0
+    }
+}
+
+impl FromStr for PdfDateWeekday {
+    type Err = chrono::ParseWeekdayError;
+
+    /// Parses short or long form weekday, case-insensitive.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.parse()?))
+    }
+}
+
+impl fmt::Display for PdfDateWeekday {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.into_long_static_str())
+    }
+}
+
+impl<'lua> IntoLua<'lua> for PdfDateWeekday {
+    #[inline]
+    fn into_lua(self, lua: &'lua Lua) -> LuaResult<LuaValue<'lua>> {
+        let (table, metatable) = lua.create_table_ext()?;
+
+        metatable.raw_set(
+            "short_name",
+            lua.create_function(move |_, ()| Ok(self.into_short_static_str().to_string()))?,
+        )?;
+
+        metatable.raw_set(
+            "long_name",
+            lua.create_function(move |_, ()| Ok(self.into_long_static_str().to_string()))?,
+        )?;
+
+        metatable.raw_set(
+            "next_weekday",
+            lua.create_function(move |_, ()| Ok(Self(self.0.succ())))?,
+        )?;
+
+        metatable.raw_set(
+            "prev_weekday",
+            lua.create_function(move |_, ()| Ok(Self(self.0.pred())))?,
+        )?;
+
+        metatable.raw_set(
+            "number_from_monday",
+            lua.create_function(move |_, ()| Ok(self.0.number_from_monday()))?,
+        )?;
+
+        metatable.raw_set(
+            "number_from_sunday",
+            lua.create_function(move |_, ()| Ok(self.0.number_from_sunday()))?,
+        )?;
+
+        metatable.raw_set(
+            "num_days_from_monday",
+            lua.create_function(move |_, ()| Ok(self.0.num_days_from_monday()))?,
+        )?;
+
+        metatable.raw_set(
+            "num_days_from_sunday",
+            lua.create_function(move |_, ()| Ok(self.0.num_days_from_sunday()))?,
+        )?;
+
+        metatable.raw_set(
+            "days_since",
+            lua.create_function(move |_, other: PdfDateWeekday| Ok(self.0.days_since(other.0)))?,
+        )?;
+
+        metatable.raw_set(
+            "__eq",
+            lua.create_function(|_, (a, b): (PdfDateWeekday, PdfDateWeekday)| Ok(a == b))?,
+        )?;
+
+        metatable.raw_set(
+            "__tostring",
+            lua.create_function(move |_, ()| Ok(self.to_string()))?,
+        )?;
+
+        // Mark table as read-only to prevent tampering without using specialized methods
+        lua.mark_readonly(table.clone())?;
+
+        Ok(LuaValue::Table(table))
+    }
+}
+
+impl<'lua> FromLua<'lua> for PdfDateWeekday {
+    #[inline]
+    fn from_lua(value: LuaValue<'lua>, _lua: &'lua Lua) -> LuaResult<Self> {
+        let from = value.type_name();
+        let to = "pdf.common.date.weekday";
+
+        match value {
+            // For a string, attempt to parse it as a weekday
+            LuaValue::String(s) => Ok(s.to_str()?.parse().map_err(LuaError::external)?),
+
+            // For a table, attempt to convert it to a string and then parse it as a weekday
+            LuaValue::Table(table) => match table.get_metatable() {
+                Some(metatable) => {
+                    let f = metatable.raw_get_ext::<_, LuaFunction>("__tostring")?;
+                    f.call(table)
+                }
+                None => Err(LuaError::FromLuaConversionError {
+                    from,
+                    to,
+                    message: Some(String::from(
+                        "table does not have __tostring metatable method",
+                    )),
+                }),
+            },
+            _ => Err(LuaError::FromLuaConversionError {
+                from,
+                to: "pdf.common.date.weekday",
+                message: None,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pdf::PdfUtils;
+    use mlua::chunk;
+
+    #[test]
+    fn should_be_able_to_retrieve_short_name_in_lua() {
+        let weekday = PdfDateWeekday::monday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.short_name()))
+                .eval::<String>()
+                .unwrap(),
+            "mon"
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_retrieve_long_name_in_lua() {
+        let weekday = PdfDateWeekday::monday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.long_name()))
+                .eval::<String>()
+                .unwrap(),
+            "monday"
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_next_weekday_in_lua() {
+        let weekday = PdfDateWeekday::monday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.next_weekday()))
+                .eval::<PdfDateWeekday>()
+                .unwrap(),
+            PdfDateWeekday::tuesday()
+        );
+
+        let weekday = PdfDateWeekday::saturday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.next_weekday()))
+                .eval::<PdfDateWeekday>()
+                .unwrap(),
+            PdfDateWeekday::sunday()
+        );
+
+        let weekday = PdfDateWeekday::sunday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.next_weekday()))
+                .eval::<PdfDateWeekday>()
+                .unwrap(),
+            PdfDateWeekday::monday()
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_previous_weekday_in_lua() {
+        let weekday = PdfDateWeekday::monday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.prev_weekday()))
+                .eval::<PdfDateWeekday>()
+                .unwrap(),
+            PdfDateWeekday::sunday()
+        );
+
+        let weekday = PdfDateWeekday::saturday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.prev_weekday()))
+                .eval::<PdfDateWeekday>()
+                .unwrap(),
+            PdfDateWeekday::friday()
+        );
+
+        let weekday = PdfDateWeekday::sunday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.prev_weekday()))
+                .eval::<PdfDateWeekday>()
+                .unwrap(),
+            PdfDateWeekday::saturday()
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_number_from_monday_in_lua() {
+        let weekday = PdfDateWeekday::monday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.number_from_monday()))
+                .eval::<u8>()
+                .unwrap(),
+            1
+        );
+
+        let weekday = PdfDateWeekday::saturday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.number_from_monday()))
+                .eval::<u8>()
+                .unwrap(),
+            6
+        );
+
+        let weekday = PdfDateWeekday::sunday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.number_from_monday()))
+                .eval::<u8>()
+                .unwrap(),
+            7
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_number_from_sunday_in_lua() {
+        let weekday = PdfDateWeekday::monday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.number_from_sunday()))
+                .eval::<u8>()
+                .unwrap(),
+            2
+        );
+
+        let weekday = PdfDateWeekday::saturday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.number_from_sunday()))
+                .eval::<u8>()
+                .unwrap(),
+            7
+        );
+
+        let weekday = PdfDateWeekday::sunday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.number_from_sunday()))
+                .eval::<u8>()
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_num_days_from_monday_in_lua() {
+        let weekday = PdfDateWeekday::monday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.num_days_from_monday()))
+                .eval::<u8>()
+                .unwrap(),
+            0
+        );
+
+        let weekday = PdfDateWeekday::saturday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.num_days_from_monday()))
+                .eval::<u8>()
+                .unwrap(),
+            5
+        );
+
+        let weekday = PdfDateWeekday::sunday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.num_days_from_monday()))
+                .eval::<u8>()
+                .unwrap(),
+            6
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_num_days_from_sunday_in_lua() {
+        let weekday = PdfDateWeekday::monday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.num_days_from_sunday()))
+                .eval::<u8>()
+                .unwrap(),
+            1
+        );
+
+        let weekday = PdfDateWeekday::saturday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.num_days_from_sunday()))
+                .eval::<u8>()
+                .unwrap(),
+            6
+        );
+
+        let weekday = PdfDateWeekday::sunday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.num_days_from_sunday()))
+                .eval::<u8>()
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_get_days_since_weekday_in_lua() {
+        let weekday = PdfDateWeekday::monday();
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.days_since("monday")))
+                .eval::<u8>()
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.days_since("tuesday")))
+                .eval::<u8>()
+                .unwrap(),
+            6
+        );
+        assert_eq!(
+            Lua::new()
+                .load(chunk!($weekday.days_since("sunday")))
+                .eval::<u8>()
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_convert_from_lua() {
+        // Can convert long string to weekday
+        assert_eq!(
+            Lua::new()
+                .load(chunk!("monday"))
+                .eval::<PdfDateWeekday>()
+                .unwrap(),
+            PdfDateWeekday::monday(),
+        );
+        assert_eq!(
+            Lua::new()
+                .load(chunk!("tuesday"))
+                .eval::<PdfDateWeekday>()
+                .unwrap(),
+            PdfDateWeekday::tuesday(),
+        );
+        assert_eq!(
+            Lua::new()
+                .load(chunk!("wednesday"))
+                .eval::<PdfDateWeekday>()
+                .unwrap(),
+            PdfDateWeekday::wednesday(),
+        );
+        assert_eq!(
+            Lua::new()
+                .load(chunk!("thursday"))
+                .eval::<PdfDateWeekday>()
+                .unwrap(),
+            PdfDateWeekday::thursday(),
+        );
+        assert_eq!(
+            Lua::new()
+                .load(chunk!("friday"))
+                .eval::<PdfDateWeekday>()
+                .unwrap(),
+            PdfDateWeekday::friday(),
+        );
+        assert_eq!(
+            Lua::new()
+                .load(chunk!("saturday"))
+                .eval::<PdfDateWeekday>()
+                .unwrap(),
+            PdfDateWeekday::saturday(),
+        );
+        assert_eq!(
+            Lua::new()
+                .load(chunk!("sunday"))
+                .eval::<PdfDateWeekday>()
+                .unwrap(),
+            PdfDateWeekday::sunday(),
+        );
+
+        // Can convert table with tostring metatable function to weekday
+        assert_eq!(
+            Lua::new()
+                .load(chunk!(setmetatable({}, {
+                    __tostring = function()
+                        return "monday"
+                    end
+                })))
+                .eval::<PdfDateWeekday>()
+                .unwrap(),
+            PdfDateWeekday::monday(),
+        );
+    }
+
+    #[test]
+    fn should_be_able_to_convert_into_lua() {
+        let weekday = PdfDateWeekday::monday();
+        Lua::new()
+            .load(chunk! {
+                local u = $PdfUtils
+                u.assert_deep_equal(tostring($weekday), "monday")
+            })
+            .exec()
+            .expect("Assertion failed");
+
+        let weekday = PdfDateWeekday::tuesday();
+        Lua::new()
+            .load(chunk! {
+                local u = $PdfUtils
+                u.assert_deep_equal(tostring($weekday), "tuesday")
+            })
+            .exec()
+            .expect("Assertion failed");
+
+        let weekday = PdfDateWeekday::wednesday();
+        Lua::new()
+            .load(chunk! {
+                local u = $PdfUtils
+                u.assert_deep_equal(tostring($weekday), "wednesday")
+            })
+            .exec()
+            .expect("Assertion failed");
+
+        let weekday = PdfDateWeekday::thursday();
+        Lua::new()
+            .load(chunk! {
+                local u = $PdfUtils
+                u.assert_deep_equal(tostring($weekday), "thursday")
+            })
+            .exec()
+            .expect("Assertion failed");
+
+        let weekday = PdfDateWeekday::friday();
+        Lua::new()
+            .load(chunk! {
+                local u = $PdfUtils
+                u.assert_deep_equal(tostring($weekday), "friday")
+            })
+            .exec()
+            .expect("Assertion failed");
+
+        let weekday = PdfDateWeekday::saturday();
+        Lua::new()
+            .load(chunk! {
+                local u = $PdfUtils
+                u.assert_deep_equal(tostring($weekday), "saturday")
+            })
+            .exec()
+            .expect("Assertion failed");
+
+        let weekday = PdfDateWeekday::sunday();
+        Lua::new()
+            .load(chunk! {
+                local u = $PdfUtils
+                u.assert_deep_equal(tostring($weekday), "sunday")
+            })
+            .exec()
+            .expect("Assertion failed");
+    }
+}


### PR DESCRIPTION

Summary: Adds a new `PdfDateWeekday` that wraps `chrono::Weekday`, introducing it as a field on `PdfDate`. Additionally, adds more testing across `PdfDate` and introduces functions to go to the beginning and end of a year, month, and week.

Test Plan: `cargo test`
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/chipsenkbeil/makepdf/pull/23).
* #22
* __->__ #23