### PR TITLE
Add weeks_in_month_XYZ

### DIFF
--- a/assets/scripts/definitions.lua
+++ b/assets/scripts/definitions.lua
@@ -214,6 +214,14 @@ function PdfDate.beginning_of_week_monday() end
 ---@return pdf.common.Date|nil
 function PdfDate.end_of_week_monday() end
 
+---Returns total calendar weeks the month of the date spans where beginning of week starts on Sunday.
+---@return integer
+function PdfDate.weeks_in_month_sunday() end
+
+---Returns total calendar weeks the month of the date spans where beginning of week starts on Monday.
+---@return integer
+function PdfDate.weeks_in_month_monday() end
+
 ---@class pdf.common.DateWeekday
 local PdfDateWeekday = {}
 


### PR DESCRIPTION

Summary: Adds `weeks_in_month_sunday()` and `weeks_in_month_monday()` to `PdfDate` that support returning the number of calendar weeks that a date's month spans when treating the beginning of the week as Sunday or Monday respectively.

Test Plan: `cargo test`
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/chipsenkbeil/makepdf/pull/24).
* #22
* __->__ #24