### PR TITLE
Add additional bounds manipulation methods

### DIFF
--- a/assets/scripts/definitions.lua
+++ b/assets/scripts/definitions.lua
@@ -115,6 +115,42 @@ local PdfBounds = {}
 ---@return pdf.common.Bounds
 function PdfBounds:align_to(bounds, align) end
 
+---Moves the bounds to the specified x & y position for the lower-left point,
+---returning updated bounds.
+---
+---Both the `x` and `y` fields are optional, so you can supply just one to
+---only affect that axis.
+---@param opts? {x?:number, y?:number}
+---@return pdf.common.Bounds
+function PdfBounds:move_to(opts) end
+
+---Shifts the bounds by the specified x & y offset, returning updated bounds.
+---
+---Both the `x` and `y` fields are optional, so you can supply just one to
+---only affect that axis.
+---@param opts? {x?:number, y?:number}
+---@return pdf.common.Bounds
+function PdfBounds:shift_by(opts) end
+
+---Scales the bounds to the specified width & height, returning updated bounds.
+---
+---Both the `width` and `height` fields are optional, so you can supply just
+---one to only affect that dimension.
+---@param opts? {width?:number, height?:number}
+---@return pdf.common.Bounds
+function PdfBounds:scale_to(opts) end
+
+---Scales the bounds by a factor of width & height, returning updated bounds.
+---
+---For example, a `width` of 2 will double the width of the bounds and a
+---`height` of 0.5 will shrink the height of the bounds to be half the size.
+---
+---Both the `width` and `height` fields are optional, so you can supply just one
+---to only affect that dimension.
+---@param opts? {width?:number, height?:number}
+---@return pdf.common.Bounds
+function PdfBounds:scale_by_factor(opts) end
+
 ---Calculates the width of the bounds.
 ---@return number
 function PdfBounds:width() end


### PR DESCRIPTION

Summary: Adds `shift_by`, `move_to`, `scale_to`, and `scale_by_factor` methods to `PdfBounds` both in Rust and Lua.

Test Plan: `cargo test`
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/chipsenkbeil/makepdf/pull/28).
* #29
* __->__ #28