### PR TITLE
Add padding support to bounds

### DIFF
--- a/assets/scripts/definitions.lua
+++ b/assets/scripts/definitions.lua
@@ -84,6 +84,7 @@ pdf.planner = {
 ---@alias pdf.common.Align {h:pdf.common.HorizontalAlign, v:pdf.common.VerticalAlign}
 ---@alias pdf.common.HorizontalAlign "left"|"middle"|"right"
 ---@alias pdf.common.VerticalAlign "top"|"middle"|"bottom"
+---@alias pdf.common.Padding {top:number, right:number, bottom:number, left:number}
 
 ---@alias pdf.common.Link
 ---| {type:"goto", page:integer}
@@ -103,6 +104,13 @@ pdf.planner = {
 ---| {[1]:{[1]:number, [2]:number}, [2]:{[1]:number, [2]:number}}
 ---| {[1]:number, [2]:number, [3]:number, [4]:number}
 
+---@alias pdf.common.PaddingArg
+---| {top?:number, right?:number, bottom?:number, left?:number}
+---| {[1]:number, [2]:number, [3]:number, [4]:number}
+---| {[1]:number, [2]:number, [3]:number}
+---| {[1]:number, [2]:number}
+---| {[1]:number}
+---| number
 
 ---@class pdf.common.Bounds
 ---@field ll pdf.common.Point
@@ -114,6 +122,13 @@ local PdfBounds = {}
 ---@param align pdf.common.Align
 ---@return pdf.common.Bounds
 function PdfBounds:align_to(bounds, align) end
+
+---Returns a copy of bounds with padding applied.
+---
+---All padding fields are optional and default to 0.
+---@param padding? pdf.common.PaddingArg
+---@return pdf.common.Bounds
+function PdfBounds:with_padding(padding) end
 
 ---Moves the bounds to the specified x & y position for the lower-left point,
 ---returning updated bounds.

--- a/src/pdf/common/padding.rs
+++ b/src/pdf/common/padding.rs
@@ -12,7 +12,7 @@ pub struct PdfPadding {
 }
 
 impl PdfPadding {
-    /// Create a new space instance from the individual params.
+    /// Create a new padding instance from the individual params.
     #[inline]
     pub const fn new(top: Mm, right: Mm, bottom: Mm, left: Mm) -> Self {
         Self {
@@ -23,46 +23,46 @@ impl PdfPadding {
         }
     }
 
-    /// Create a new space instance from the individual params.
+    /// Create a new padding instance from the individual params.
     #[inline]
     pub const fn new_f32(top: f32, right: f32, bottom: f32, left: f32) -> Self {
         Self::new(Mm(top), Mm(right), Mm(bottom), Mm(left))
     }
 
-    /// Create a new space instance from top/bottom and right/left.
+    /// Create a new padding instance from top/bottom and right/left.
     #[inline]
     pub const fn from_pair(top_bottom: Mm, right_left: Mm) -> Self {
         Self::new(top_bottom, right_left, top_bottom, right_left)
     }
 
-    /// Create a new space instance from top, right/left, bottom.
+    /// Create a new padding instance from top, right/left, bottom.
     #[inline]
     pub const fn from_pair_f32(top_bottom: f32, right_left: f32) -> Self {
         Self::new_f32(top_bottom, right_left, top_bottom, right_left)
     }
 
-    /// Create a new space instance from top, right/left, bottom.
+    /// Create a new padding instance from top, right/left, bottom.
     #[inline]
     pub const fn from_triple(top: Mm, right_left: Mm, bottom: Mm) -> Self {
         Self::new(top, right_left, bottom, right_left)
     }
 
-    /// Create a new space instance from top, right/left, bottom.
+    /// Create a new padding instance from top, right/left, bottom.
     #[inline]
     pub const fn from_triple_f32(top: f32, right_left: f32, bottom: f32) -> Self {
         Self::new_f32(top, right_left, bottom, right_left)
     }
 
-    /// Create a new space instance where all sides match `space`.
+    /// Create a new padding instance where all sides match `padding`.
     #[inline]
-    pub const fn from_single(space: Mm) -> Self {
-        Self::new(space, space, space, space)
+    pub const fn from_single(padding: Mm) -> Self {
+        Self::new(padding, padding, padding, padding)
     }
 
-    /// Create a new space instance where all sides match `space`.
+    /// Create a new padding instance where all sides match `padding`.
     #[inline]
-    pub const fn from_single_f32(space: f32) -> Self {
-        Self::new_f32(space, space, space, space)
+    pub const fn from_single_f32(padding: f32) -> Self {
+        Self::new_f32(padding, padding, padding, padding)
     }
 }
 
@@ -93,7 +93,7 @@ impl<'lua> FromLua<'lua> for PdfPadding {
                     .collect::<LuaResult<_>>()
                     .ok();
 
-                // If we have vec, check to make sure we have four items, and use them as space
+                // If we have vec, check to make sure we have four items, and use them as padding
                 if let Some(v) = maybe_vec_f32 {
                     if v.len() >= 4 {
                         return Ok(Self::new_f32(v[0], v[1], v[2], v[3]));
@@ -110,15 +110,27 @@ impl<'lua> FromLua<'lua> for PdfPadding {
                 }
 
                 Ok(Self {
-                    top: Mm(table.raw_get_ext("top")?),
-                    right: Mm(table.raw_get_ext("right")?),
-                    bottom: Mm(table.raw_get_ext("bottom")?),
-                    left: Mm(table.raw_get_ext("left")?),
+                    top: table
+                        .raw_get_ext::<_, Option<f32>>("top")?
+                        .map(Mm)
+                        .unwrap_or_default(),
+                    right: table
+                        .raw_get_ext::<_, Option<f32>>("right")?
+                        .map(Mm)
+                        .unwrap_or_default(),
+                    bottom: table
+                        .raw_get_ext::<_, Option<f32>>("bottom")?
+                        .map(Mm)
+                        .unwrap_or_default(),
+                    left: table
+                        .raw_get_ext::<_, Option<f32>>("left")?
+                        .map(Mm)
+                        .unwrap_or_default(),
                 })
             }
             _ => Err(LuaError::FromLuaConversionError {
                 from: value.type_name(),
-                to: "pdf.common.space",
+                to: "pdf.common.padding",
                 message: None,
             }),
         }
@@ -133,19 +145,25 @@ mod tests {
 
     #[test]
     fn should_be_able_to_convert_from_lua() {
-        // Can convert integer into space
+        // Can convert empty table into zero padding
+        assert_eq!(
+            Lua::new().load(chunk!({})).eval::<PdfPadding>().unwrap(),
+            PdfPadding::new_f32(0.0, 0.0, 0.0, 0.0),
+        );
+
+        // Can convert integer into padding
         assert_eq!(
             Lua::new().load(chunk!(1)).eval::<PdfPadding>().unwrap(),
             PdfPadding::new_f32(1.0, 1.0, 1.0, 1.0),
         );
 
-        // Can convert number into space
+        // Can convert number into padding
         assert_eq!(
             Lua::new().load(chunk!(1.5)).eval::<PdfPadding>().unwrap(),
             PdfPadding::new_f32(1.5, 1.5, 1.5, 1.5),
         );
 
-        // Can convert { number } into space
+        // Can convert { number } into padding
         assert_eq!(
             Lua::new()
                 .load(chunk!({ 1.5 }))
@@ -154,7 +172,7 @@ mod tests {
             PdfPadding::new_f32(1.5, 1.5, 1.5, 1.5),
         );
 
-        // Can convert { number, number } into space
+        // Can convert { number, number } into padding
         assert_eq!(
             Lua::new()
                 .load(chunk!({1.5, 2.5}))
@@ -163,7 +181,7 @@ mod tests {
             PdfPadding::new_f32(1.5, 2.5, 1.5, 2.5),
         );
 
-        // Can convert { number, number, number } into space
+        // Can convert { number, number, number } into padding
         assert_eq!(
             Lua::new()
                 .load(chunk!({1.5, 2.5, 3.5}))
@@ -172,7 +190,7 @@ mod tests {
             PdfPadding::new_f32(1.5, 2.5, 3.5, 2.5),
         );
 
-        // Can convert { number, number, number, number } into space
+        // Can convert { number, number, number, number } into padding
         assert_eq!(
             Lua::new()
                 .load(chunk!({1.5, 2.5, 3.5, 4.5}))
@@ -181,7 +199,7 @@ mod tests {
             PdfPadding::new_f32(1.5, 2.5, 3.5, 4.5),
         );
 
-        // Can convert { top, right, bottom, left } into space
+        // Can convert { top, right, bottom, left } into padding
         assert_eq!(
             Lua::new()
                 .load(chunk!({ top = 1.5, right = 2.5, bottom = 3.5, left = 4.5 }))
@@ -189,16 +207,46 @@ mod tests {
                 .unwrap(),
             PdfPadding::new_f32(1.5, 2.5, 3.5, 4.5),
         );
+
+        // Can convert missing padding fields to zero padding
+        assert_eq!(
+            Lua::new()
+                .load(chunk!({ top = 1.5 }))
+                .eval::<PdfPadding>()
+                .unwrap(),
+            PdfPadding::new_f32(1.5, 0.0, 0.0, 0.0),
+        );
+        assert_eq!(
+            Lua::new()
+                .load(chunk!({ right = 2.5 }))
+                .eval::<PdfPadding>()
+                .unwrap(),
+            PdfPadding::new_f32(0.0, 2.5, 0.0, 0.0),
+        );
+        assert_eq!(
+            Lua::new()
+                .load(chunk!({ bottom = 3.5 }))
+                .eval::<PdfPadding>()
+                .unwrap(),
+            PdfPadding::new_f32(0.0, 0.0, 3.5, 0.0),
+        );
+        assert_eq!(
+            Lua::new()
+                .load(chunk!({ left = 4.5 }))
+                .eval::<PdfPadding>()
+                .unwrap(),
+            PdfPadding::new_f32(0.0, 0.0, 0.0, 4.5),
+        );
     }
 
     #[test]
     fn should_be_able_to_convert_into_lua() {
-        let space = PdfPadding::new_f32(1.0, 2.0, 3.0, 4.0);
+        let padding = PdfPadding::new_f32(1.0, 2.0, 3.0, 4.0);
 
         Lua::new()
             .load(chunk! {
                 local u = $PdfUtils
-                u.assert_deep_equal($space, { top = 1, right = 2, bottom = 3, left = 4 })
+                u.assert_deep_equal($padding, { top = 1, right = 2, bottom = 3, left = 4 })
             })
             .exec()
             .expect("Assertion failed");


### PR DESCRIPTION

Summary: Adds `with_padding` function to `PdfBounds` both in Rust and Lua to support applying padding to the dimensions of bounds.

Test Plan: `cargo test`
