### PR TITLE
Add dash pattern, cap style, and join style for rect outline

### DIFF
--- a/assets/scripts/definitions.lua
+++ b/assets/scripts/definitions.lua
@@ -539,6 +539,9 @@ function pdf.object.line(tbl) end
 ---@field outline_thickness number|nil
 ---@field mode pdf.common.PaintMode|nil
 ---@field order pdf.common.WindingOrder|nil
+---@field dash_pattern pdf.common.line.DashPattern|nil
+---@field cap_style pdf.common.line.CapStyle|nil
+---@field join_style pdf.common.line.JoinStyle|nil
 ---@field link pdf.common.Link|nil
 local PdfObjectRect = {}
 
@@ -564,6 +567,9 @@ function PdfObjectRect:bounds() end
 ---@field outline_thickness number|nil
 ---@field mode pdf.common.PaintMode|nil
 ---@field order pdf.common.WindingOrder|nil
+---@field dash_pattern pdf.common.line.DashPattern|nil
+---@field cap_style pdf.common.line.CapStyle|nil
+---@field join_style pdf.common.line.JoinStyle|nil
 ---@field link pdf.common.LinkLike|nil
 
 ---@class pdf.object.RectLike1: pdf.object.RectLikeBase


### PR DESCRIPTION

Summary: Adds support for configuring the dash pattern, cap style, and join style for the outline of a rect.

Test Plan: `cargo test`
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/chipsenkbeil/makepdf/pull/43).
* #44
* __->__ #43