### PR TITLE
Add dash pattern, cap style, and join style for shape outline

### DIFF
--- a/assets/scripts/definitions.lua
+++ b/assets/scripts/definitions.lua
@@ -607,6 +607,9 @@ function pdf.object.rect(tbl) end
 ---@field outline_thickness number|nil
 ---@field mode pdf.common.PaintMode|nil
 ---@field order pdf.common.WindingOrder|nil
+---@field dash_pattern pdf.common.line.DashPattern|nil
+---@field cap_style pdf.common.line.CapStyle|nil
+---@field join_style pdf.common.line.JoinStyle|nil
 ---@field link pdf.common.Link|nil
 local PdfObjectShape = {}
 
@@ -628,6 +631,9 @@ function PdfObjectShape:bounds() end
 ---@field outline_thickness number|nil
 ---@field mode pdf.common.PaintMode|nil
 ---@field order pdf.common.WindingOrder|nil
+---@field dash_pattern pdf.common.line.DashPattern|nil
+---@field cap_style pdf.common.line.CapStyle|nil
+---@field join_style pdf.common.line.JoinStyle|nil
 ---@field link pdf.common.LinkLike|nil
 
 ---Creates a new shape object.


### PR DESCRIPTION

Summary: Adds support for configuring the dash pattern, cap style, and join style for the outline of a shape.

Test Plan: `cargo test`
