### PR TITLE
Update `PdfAlign` to use defaults for `v` and `h` if not provided when converting from Lua

### DIFF
--- a/src/pdf/common/align.rs
+++ b/src/pdf/common/align.rs
@@ -36,8 +36,8 @@ impl<'lua> FromLua<'lua> for PdfAlign {
         let from = value.type_name();
         match value {
             LuaValue::Table(tbl) => Ok(Self {
-                h: tbl.raw_get_ext("h")?,
-                v: tbl.raw_get_ext("v")?,
+                h: tbl.raw_get_ext::<_, Option<_>>("h")?.unwrap_or_default(),
+                v: tbl.raw_get_ext::<_, Option<_>>("v")?.unwrap_or_default(),
             }),
             _ => Err(LuaError::FromLuaConversionError {
                 from,


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/chipsenkbeil/makepdf/pull/46).
* #22
* #47
* __->__ #46