### PR TITLE
Add `to_precision()` to `PdfBounds` and `PdfPoint` and support `pdf.utils.point()` since point now has a metatable metho

### DIFF
--- a/assets/scripts/definitions.lua
+++ b/assets/scripts/definitions.lua
@@ -83,7 +83,6 @@ pdf.planner = {
 -- COMMON TYPES
 -------------------------------------------------------------------------------
 
----@alias pdf.common.Point {x:number, y:number}
 ---@alias pdf.common.PaintMode "clip"|"fill"|"fill_stroke"|"stroke"
 ---@alias pdf.common.WindingOrder "even_odd"|"non_zero"
 ---@alias pdf.common.Align {h:pdf.common.HorizontalAlign, v:pdf.common.VerticalAlign}
@@ -163,6 +162,11 @@ function PdfBounds:align_to(bounds, align) end
 ---@param padding? pdf.common.PaddingLike
 ---@return pdf.common.Bounds
 function PdfBounds:with_padding(padding) end
+
+---Returns a copy of bounds with points rounded to precision.
+---@param precision integer
+---@return pdf.common.Bounds
+function PdfBounds:with_precision(precision) end
 
 ---Moves the bounds to the specified x & y position for the lower-left point,
 ---returning updated bounds.
@@ -373,6 +377,16 @@ function PdfDateWeekday:days_since(weekday) end
 ---Converts weekday into the long string form.
 ---@return string
 function PdfDateWeekday:__tostring() end
+
+---@class pdf.common.Point
+---@field x number
+---@field y number
+local PdfPoint = {}
+
+---Returns a copy of point with x & y rounded to precision.
+---@param precision integer
+---@return pdf.common.Point
+function PdfPoint:with_precision(precision) end
 
 -------------------------------------------------------------------------------
 -- RUNTIME TYPES
@@ -771,6 +785,11 @@ function pdf.utils.color(tbl) end
 ---@param tbl pdf.common.LinkLike
 ---@return pdf.common.Link
 function pdf.utils.link(tbl) end
+
+---Creates a point instance, or throws an error if invalid.
+---@param tbl pdf.common.PointLike
+---@return pdf.common.Point
+function pdf.utils.point(tbl) end
 
 ---Checks if two values are deeply equal, which involves recursively
 ---traversing tables.

--- a/src/pdf/common/bounds.rs
+++ b/src/pdf/common/bounds.rs
@@ -61,6 +61,15 @@ impl PdfBounds {
         PdfPoint::new(self.ur.x, self.ll.y)
     }
 
+    /// Creates a copy of the bounds where the points have been rounded to the specified
+    /// `precision`.
+    pub fn to_precision(&self, precision: u32) -> Self {
+        Self::new(
+            self.ll.to_precision(precision),
+            self.ur.to_precision(precision),
+        )
+    }
+
     /// Converts coordinates into bounds.
     #[inline]
     pub const fn from_coords(llx: Mm, lly: Mm, urx: Mm, ury: Mm) -> Self {
@@ -209,6 +218,13 @@ impl<'lua> IntoLua<'lua> for PdfBounds {
                     None => Ok(this),
                 },
             )?,
+        )?;
+
+        metatable.raw_set(
+            "with_precision",
+            lua.create_function(|_, (this, precision): (Self, u32)| {
+                Ok(this.to_precision(precision))
+            })?,
         )?;
 
         metatable.raw_set(

--- a/src/pdf/utils.rs
+++ b/src/pdf/utils.rs
@@ -1,4 +1,4 @@
-use crate::pdf::{PdfBounds, PdfColor, PdfLink, PdfLuaExt};
+use crate::pdf::{PdfBounds, PdfColor, PdfLink, PdfLuaExt, PdfPoint};
 use mlua::prelude::*;
 use printpdf::{Mm, Pt};
 use tailcall::tailcall;
@@ -182,6 +182,11 @@ impl<'lua> IntoLua<'lua> for PdfUtils {
         )?;
 
         metatable.raw_set("link", lua.create_function(|_, link: PdfLink| Ok(link))?)?;
+
+        metatable.raw_set(
+            "point",
+            lua.create_function(|_, point: PdfPoint| Ok(point))?,
+        )?;
 
         metatable.raw_set(
             "deep_equal",
@@ -431,6 +436,20 @@ mod tests {
                 }), {
                     type = "uri",
                     uri = "https://example.com",
+                })
+            })
+            .exec()
+            .expect("Assertion failed");
+    }
+
+    #[test]
+    fn should_support_converting_value_to_point() {
+        Lua::new()
+            .load(chunk! {
+                local u = $PdfUtils
+                u.assert_deep_equal(u.point({ 1, 2 }), {
+                    x = 1,
+                    y = 2,
                 })
             })
             .exec()


### PR DESCRIPTION
d
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/chipsenkbeil/makepdf/pull/49).
* #22
* #51
* #50
* __->__ #49