### PR TITLE
Add `pdf.utils.date()` function to create dates and support date-like formats

### DIFF
--- a/assets/scripts/definitions.lua
+++ b/assets/scripts/definitions.lua
@@ -128,6 +128,11 @@ pdf.planner = {
 ---| {[1]:number}
 ---| number
 
+---@alias pdf.common.DateLike
+---| string #representing a date in the form YYYY-MM-DD
+---| {year:integer, month:integer, day:integer}
+---| pdf.common.Date
+
 ---@class pdf.common.line.DashPattern
 ---@field offset integer
 ---@field dash_1 integer|nil
@@ -827,6 +832,11 @@ function pdf.utils.bounds(tbl) end
 ---@param tbl pdf.common.ColorLike
 ---@return pdf.common.Color
 function pdf.utils.color(tbl) end
+
+---Creates a date instance, or throws an error if invalid.
+---@param tbl pdf.common.DateLike
+---@return pdf.common.Date
+function pdf.utils.date(tbl) end
 
 ---Creates a link instance, or throws an error if invalid.
 ---@param tbl pdf.common.LinkLike

--- a/src/pdf/utils.rs
+++ b/src/pdf/utils.rs
@@ -1,4 +1,4 @@
-use crate::pdf::{PdfBounds, PdfColor, PdfLink, PdfLuaExt, PdfPadding, PdfPoint};
+use crate::pdf::{PdfBounds, PdfColor, PdfDate, PdfLink, PdfLuaExt, PdfPadding, PdfPoint};
 use mlua::prelude::*;
 use printpdf::{Mm, Pt};
 use tailcall::tailcall;
@@ -180,6 +180,8 @@ impl<'lua> IntoLua<'lua> for PdfUtils {
             "color",
             lua.create_function(|_, color: PdfColor| Ok(color))?,
         )?;
+
+        metatable.raw_set("date", lua.create_function(|_, date: PdfDate| Ok(date))?)?;
 
         metatable.raw_set("link", lua.create_function(|_, link: PdfLink| Ok(link))?)?;
 


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/chipsenkbeil/makepdf/pull/59).
* #22
* #62
* #61
* #60
* __->__ #59